### PR TITLE
Fix mongo bind_ip setup

### DIFF
--- a/templates/mongodb/mongodb.conf.erb
+++ b/templates/mongodb/mongodb.conf.erb
@@ -6,10 +6,9 @@ logpath=/var/log/mongodb/mongodb.log
 # fork and run in background
 fork = true
 
-#Default binds to all interfaces
-#bind_ip = 127.0.0.1,<%= ipaddress %>
-
-#port = 27017
+#Default binds to all interfaces which conflicts with mongo running on gears
+bind_ip = 127.0.0.1
+port = 27017
 
 dbpath=/var/lib/mongodb
 

--- a/templates/mongodb/oo-mongo-setup
+++ b/templates/mongodb/oo-mongo-setup
@@ -19,6 +19,8 @@ require 'rubygems'
 require 'fileutils'
 require 'logger'
 require 'open4'
+require 'socket'
+
 $log = Logger.new(STDOUT)
 $log.level = Logger::INFO
 
@@ -95,6 +97,9 @@ else
   $log.info "......disable mongo auth"
   insert_if_not_exist("/etc/mongodb.conf", /^smallfiles = .*$/, "smallfiles = true")
   find_and_replace("/etc/mongodb.conf", /^#?auth = .*$/, "auth = false")
+  hostname = Socket.gethostname
+  ipaddr   = IPSocket.getaddress(hostname)
+  find_and_replace("/etc/mongodb.conf", /^#?bind_ip = .*$/, "bind_ip = 127.0.0.1,#{ipaddr}")
   restart_mongo
   $log.info "......set db admin users"
   run "/usr/bin/mongo localhost/openshift_broker_dev --eval 'db.addUser(\"openshift\", \"mooo\")'"


### PR DESCRIPTION
Mongo was binding to all interfaces which prevented mongo instances from starting on gears. This fix reverts an earlier fix in dce2ad9a
