### PR TITLE
Add cartridge Apache conf.

### DIFF
--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -428,6 +428,20 @@ class openshift_origin::node {
     }
   }
 
+  if ($::openshift_origin::configure_node == true) {
+    if $::operatingsystem == "Fedora" {
+      file { 'allow cartridge files through apache':
+        ensure  => present,
+        path    => '/etc/httpd/conf.d/cartridge_files.conf',
+        content => template('openshift_origin/node/cartridge_files.conf.erb'),
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0660',
+        require =>  Package['httpd'],
+      }
+    }
+  }
+
   package { [
     'openshift-origin-cartridge-abstract',
     'openshift-origin-cartridge-10gen-mms-agent-0.1',

--- a/templates/node/cartridge_files.conf.erb
+++ b/templates/node/cartridge_files.conf.erb
@@ -1,0 +1,6 @@
+#
+# Cartridges may expose files through the FrontendHttpServer connect call.
+#
+<Directory /usr/libexec/openshift/cartridges/*/info/configuration >
+    Require all granted
+</Directory>


### PR DESCRIPTION
Allow cartridges to expose files in their config directory through Apache.
