### PR TITLE
Moving disable of IPv6 out of the script to a more appropriate location.

### DIFF
--- a/templates/node/sysctl.conf.erb
+++ b/templates/node/sysctl.conf.erb
@@ -43,4 +43,6 @@ kernel.shmall = 4294967296
 kernel.sem = 250  32000 32  4096
 net.ipv4.ip_local_port_range = 15000 35530
 net.netfilter.nf_conntrack_max = 1048576
+net.ipv6.conf.all.disable_ipv6 = 1
+net.ipv6.conf.default.disable_ipv6 = 1
 


### PR DESCRIPTION
The oo-admin-ctl-gears script used to disable IPv6.  That script is being rewritten and I'm getting rid of tasks that don't properly belong to gear start as part of the rewrite.  

Moving it properly to /etc/sysctl.conf so its easily discoverable and changeable as OpenShift evolves to include IPv6.
