### PR TITLE
Fedora 19 and libvirt-lxc support

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -99,37 +99,33 @@ class openshift_origin::broker {
   if $::operatingsystem == 'Fedora' {
     ensure_resource('package', 'mariadb-devel', {
         ensure => 'latest',
-        alias  => 'mysql-devel'
-      }
-    )
-
-    ensure_resource('package', 'mysql', {
-        provider => 'gem',
-        require  => [Package['ruby-devel'], Package['mysql-devel']]
+        alias  => 'mariadb-devel',
       }
     )
     
-    ensure_resource('package', 'mongoid', {
-        ensure   => '3.0.21',
-        provider => 'gem',
+    ensure_resource('package', 'rubygem-mongoid', {
+        ensure  => 'latest',
+        require => Yumrepo[openshift-origin-deps],
+        alias   => 'mongoid'
       }
     )
 
-    ensure_resource('package', 'moped', {
-        ensure   => '1.3.2',
-        provider => 'gem',
+    ensure_resource('package', 'rubygem-moped', {
+        ensure  => 'latest',
+        require => Yumrepo[openshift-origin-deps],
+        alias   => 'moped'
       }
     )
     
-    ensure_resource('package', 'origin', {
-        ensure   => '1.0.11',
-        provider => 'gem',
+    ensure_resource('package', 'rubygem-origin', {
+        ensure   => 'latest',
+        require  => Yumrepo[openshift-origin-deps],
+        alias    => 'origin'
       }
     )
 
-    ensure_resource('package', 'minitest', {
-        ensure   => '3.2.0',
-        provider => 'gem',
+    ensure_resource('package', 'rubygem-minitest', {
+        ensure   => 'latest',
         alias    => 'minitest'
       }
     )
@@ -282,10 +278,10 @@ class openshift_origin::broker {
       }
     )
 
-    ensure_resource('package', 'mocha', {
-        ensure   => '0.12.10',
-        provider => 'gem',
-        alias    => 'mocha'
+    ensure_resource('package', 'rubygem-mocha', {
+        ensure  => 'latest',
+        require => Yumrepo[openshift-origin-deps],
+        alias   => 'mocha'
       }
     )
 
@@ -479,9 +475,10 @@ class openshift_origin::broker {
   if ($::operatingsystem == "RedHat" or $::operatingsystem == "CentOS") {
     ensure_resource('package', 'mysql-devel', {
         ensure => 'latest',
+        alias  => 'mariadb-devel',
       }
     )
-
+  
     ensure_resource('package', 'ruby193-rubygem-actionmailer', {
         ensure => 'latest',
         alias  => 'actionmailer',

--- a/manifests/console.pp
+++ b/manifests/console.pp
@@ -81,6 +81,44 @@ class openshift_origin::console {
   }
 
   if $::operatingsystem == 'Fedora' {
+
+    ensure_resource('package', 'rubygem-capybara', {
+        ensure   => 'latest',
+        alias    => 'rubygem-capybara',
+      }
+    )
+
+    ensure_resource('package', 'rubygem-poltergeist', {
+        ensure   => 'latest',
+        alias    => 'rubygem-poltergeist',
+      }
+    )
+
+    ensure_resource('package', 'rubygem-webmock', {
+        ensure   => 'latest',
+      }
+    )
+
+    ensure_resource('package', 'rubygem-simplecov', {
+        ensure   => 'latest',
+      }
+    )
+
+    ensure_resource('package', 'rubygem-mocha', {
+        ensure   => 'latest',
+      }
+    )
+
+    ensure_resource('package', 'rubygem-minitest', {
+        ensure   => 'latest',
+      }
+    )
+
+    ensure_resource('package', 'rubygem-ci_reporter', {
+        ensure   => 'latest',
+      }
+    )
+
     ensure_resource('package', 'rubygem-sass-rails', {
         ensure   => 'latest',
         alias    => 'rubygem-sass-rails',
@@ -123,15 +161,8 @@ class openshift_origin::console {
       }
     )
 
-    ensure_resource('package', 'rdiscount', {
-        ensure   => '1.6.8',
-        provider => 'gem',
-        alias    => 'rubygem-rdiscount',
-        require  => [
-            Package['ruby-devel'],
-            Package['gcc'],
-            Package['make']
-          ]
+    ensure_resource('package', 'rubygem-rdiscount', {
+        ensure   => 'latest',
       }
     )
 
@@ -142,24 +173,13 @@ class openshift_origin::console {
       }
     )
 
-    ensure_resource('package', 'net-http-persistent', {
-        ensure   => '2.7',
-        provider => 'gem',
-        alias    => 'rubygem-net-http-persistent'
-      }
-    )
-
-    ensure_resource('package', 'haml', {
-        ensure   => '3.1.7',
-        provider => 'gem',
-        alias    => 'rubygem-haml'
-      }
-    )
-
-    ensure_resource('package', 'rubygem-ci_reporter', {
+    ensure_resource('package', 'rubygem-net-http-persistent', {
         ensure   => 'latest',
-        alias    => 'ci_reporter',
-        require => Yumrepo[openshift-origin-deps],
+      }
+    )
+
+    ensure_resource('package', 'rubygem-haml', {
+        ensure   => 'latest',
       }
     )
   }
@@ -277,6 +297,12 @@ class openshift_origin::console {
       Package['rubygem-haml'],
       Package['rubygem-formtastic'],
       Package['rubygem-ci_reporter'],
+      Package['rubygem-minitest'],
+      Package['rubygem-mocha'],
+      Package['rubygem-simplecov'],
+      Package['rubygem-webmock'],
+      Package['rubygem-poltergeist'],
+      Package['rubygem-capybara'],
       File['openshift console.conf'],
     ],
     refreshonly => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -145,6 +145,7 @@ class openshift_origin (
   $configure_node             = true,
   $set_sebooleans             = true,
   $install_login_shell        = false,
+  $eth_device                 = 'eth0',
   $install_repo               = 'nightlies',
   $named_ipaddress            = $::ipaddress,
   $avahi_ipaddress            = $::ipaddress,
@@ -185,6 +186,7 @@ class openshift_origin (
   $development_mode           = false,
   $eth_device                 = 'eth0',
   $min_gear_uid               = 500,
+  $node_container             = 'selinux'
 ) {
   include openshift_origin::params
 
@@ -338,17 +340,21 @@ class openshift_origin (
   }
 
   ensure_resource('package', 'policycoreutils', {
-  }
+    }
   )
   ensure_resource('package', 'mcollective', {
-    require => Yumrepo['openshift-origin-deps'],
-  }
+      require => Yumrepo['openshift-origin-deps'],
+    }
   )
   ensure_resource('package', 'httpd', {
-  }
+    }
   )
   ensure_resource('package', 'openssh-server', {
-  }
+    }
+  )
+
+  ensure_resource('package', 'facter', {
+    }
   )
 
   ensure_resource('package', 'ruby-devel', {
@@ -484,6 +490,33 @@ class openshift_origin (
     exec { 'Open port for HTTPS':
       command => "${openshift_origin::params::firewall_service_cmd}https",
       require => Package['firewall-package'],
+    }
+  }
+
+  if $update_network_dns_servers == true {
+    $mac_template = "<%= scope.lookupvar('::macaddress_${::openshift_origin::eth_device}') %>"
+    $mac_address  = inline_template( $mac_template )
+    augeas { 'network setup':
+      context => "/files/etc/sysconfig/network-scripts/ifcfg-${::openshift_origin::eth_device}",
+      changes => [
+        "set DNS1 ${named_ipaddress}", 
+        "set PEERDNS no",
+        "set IPV6INIT no",
+      ],
+    }
+
+    if ($configure_named ==  true and $configure_broker ==  true) {
+      exec{ "Register host ${::hostname} with IP ${::ipaddress} with named":
+        command => "/usr/sbin/oo-register-dns -h ${::hostname} -n ${::ipaddress}",
+        require => [
+          Package['openshift-origin-msg-node-mcollective'],
+          Package['facter'],
+          Package['openshift-origin-broker-util'],
+          Service['named']
+        ]
+      }
+    } else {
+      warning 'Please make sure that $::hostname is resolvable via DNS.'
     }
   }
 

--- a/manifests/named.pp
+++ b/manifests/named.pp
@@ -133,31 +133,4 @@ class openshift_origin::named {
     enable    => true,
     require   => Exec['named restorecon'],
   }
-
-  if $::openshift_origin::update_network_dns_servers == true {
-    $mac_template = "<%= scope.lookupvar('::macaddress_${::openshift_origin::eth_device}') %>"
-    $mac_address  = inline_template( $mac_template )
-    augeas { 'network setup':
-      context => "/files/etc/sysconfig/network-scripts/ifcfg-${::openshift_origin::eth_device}",
-      changes => [
-                "set DNS1 ${::openshift_origin::named_ipaddress}",
-                #"set HWADDR ${mac_address}",
-                "set PEERDNS no"],
-      require => Service['named']
-    }
-    file { '/etc/resolv.conf':
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
-      content => "nameserver ${::openshift_origin::named_ipaddress}",
-      require => Service['named']
-    }
-    exec { 'register broker DNS':
-      command => "/usr/sbin/oo-register-dns -h ${::hostname} -n ${::ipaddress}",
-      require => [
-        Service['named'],
-        Package['openshift-origin-broker-util']
-      ]
-    }
-  }
 }

--- a/templates/mongodb/mongodb.conf.erb
+++ b/templates/mongodb/mongodb.conf.erb
@@ -18,7 +18,7 @@ pidfilepath=/var/run/mongodb/mongodb.pid
 #cpu = true
 
 # Turn on/off security.  Off is currently the default
-auth = true
+#auth = true
 
 # Verbose logging output.
 #verbose = true

--- a/templates/mongodb/oo-mongo-setup
+++ b/templates/mongodb/oo-mongo-setup
@@ -98,9 +98,16 @@ else
   $log.info "......disable mongo auth"
   insert_if_not_exist("/etc/mongodb.conf", /^smallfiles = .*$/, "smallfiles = true")
   find_and_replace("/etc/mongodb.conf", /^#?auth = .*$/, "auth = false")
-  hostname = Socket.gethostname
-  ipaddr   = IPSocket.getaddress(hostname)
-  if(ipaddr == '127.0.0.1')
+
+  begin
+    hostname = Socket.gethostname
+    ipaddr   = IPSocket.getaddress(hostname)
+  rescue
+    addresses = `ip addr`.scan(/inet ([\d]+\.[\d]+\.[\d]+\.[\d]+)/).flatten
+    ipaddr = (addresses - ["127.0.0.1"]).first
+  end
+
+  if(ipaddr == '127.0.0.1' or ipaddr.nil? or ipaddr.empty?)
     find_and_replace("/etc/mongodb.conf", /^#?bind_ip = .*$/, "bind_ip = 127.0.0.1")
   else
     find_and_replace("/etc/mongodb.conf", /^#?bind_ip = .*$/, "bind_ip = 127.0.0.1,#{ipaddr}")

--- a/templates/node/node.conf.erb
+++ b/templates/node/node.conf.erb
@@ -23,7 +23,7 @@ GEAR_MAX_UID=6500                                         # Upper bound of UID u
 <% if scope.lookupvar('::openshift_origin::user_supplementary_groups') != "" -%>
 GEAR_SUPL_GRPS="<%= scope.lookupvar('::openshift_origin::user_supplementary_groups') %>"  # Supplementary groups for gear UIDs (comma separated list)
 <% end -%>
-OPENSHIFT_NODE_PLUGINS="openshift-origin-node/plugins/unix_user_observer"                                    # Extentions to load when customize/observe openshift-origin-node models
+OPENSHIFT_NODE_PLUGINS=""                                 # Extentions to load when customize/observe openshift-origin-node models
 CARTRIDGE_BASE_PATH="/usr/libexec/openshift/cartridges"   # Locations where cartridges are installed
 LAST_ACCESS_DIR="/var/lib/openshift/.last_access"         # Location to maintain last accessed time for gears
 APACHE_ACCESS_LOG="/var/log/httpd/access_log"             # Localion of httpd for node


### PR DESCRIPTION
Make v2 carts install in offline mode (without mcollective running)
Add option to specify primary ethernet device (if not eth0)
Move additional gems to use rpm instead of rubygems website.
Add dev/test requirements when installing console
