### PR TITLE
Added check for SELinux running in enabled/permissive

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -206,6 +206,10 @@ class openshift_origin (
     fail 'Facter version needs to be updated to at least 1.6.17'
   }
 
+  if $::selinux_current_mode == 'disabled' {
+    fail 'SELinux is required for OpenShift.'
+  }
+
   $service   = $::operatingsystem ? {
     'Fedora' => '/usr/sbin/service',
     default  => '/sbin/service',


### PR DESCRIPTION
In order for SELinux to properly limit the access for gears within
OpenShift SELinux must have access controls over the system.  This
check ensures that systems are at the very least running OpenShift
in permissive mode if not enabled.
