### PR TITLE
Fix mongo setup for RHEL system

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -341,11 +341,23 @@ class openshift_origin (
   }
   )
 
-  ensure_resource('package', 'ruby-devel', {
-      ensure  => present,
-    }
-  )
-
+  if $::operatingsystem == "Fedora" {
+    ensure_resource('package', 'ruby-devel', {
+        ensure  => present,
+      }
+    )
+  } else {
+    ensure_resource('package', 'ruby193-ruby-devel', {
+        ensure => present,
+        alias => 'ruby-devel',
+      }
+    )
+    ensure_resource('package', 'ruby193-rubygems', {
+        ensure => present,
+        alias => 'rubygems',
+      }
+    )
+  }
 
   if $enable_network_services == true {
     service { [httpd, network, sshd]:

--- a/manifests/mongo.pp
+++ b/manifests/mongo.pp
@@ -41,6 +41,13 @@ class openshift_origin::mongo {
       require => Yumrepo['openshift-origin-deps'],
     }
   )
+  if $::operatingsystem != 'Fedora' {
+    ensure_resource('package', 'ruby193-ruby', {
+        ensure => present,
+        require => Yumrepo['openshift-origin-deps'],
+      }
+    )
+  }
 
   file { 'Temporarily Disable mongo auth':
     ensure  => present,
@@ -100,7 +107,13 @@ class openshift_origin::mongo {
       enable   => true,
     }
   } else {
+    $cmd = $::operatingsystem ? {
+      'Fedora' => '/usr/sbin/oo-mongo-setup',
+      default => '/usr/bin/scl enable ruby193 /usr/sbin/oo-mongo-setup',
+    }
+
     exec { '/usr/sbin/oo-mongo-setup':
+      command => $cmd,
       require => File['mongo setup script']
     }
   }


### PR DESCRIPTION
- Calling oo-mongo-setup directly in Puppet will not work
  because it is invoking the wrong ruby.
- ruby-devel dependency in init.pp should be coming from
  ruby193 SCL on RHEL; resolve rubygems in a similar fashion
  as well
