### PR TITLE
<puppet manifests> Add File resource to clean up broker and console Gemf...

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -1126,12 +1126,12 @@ class openshift_origin::broker {
   # by the following Exec has the appropriate permissions (otherwise
   # it is created as owned by root:root)  
   file { '/var/www/openshift/broker/Gemfile.lock':
+    ensure    => 'present',
     owner     => 'apache',
     group     => 'apache',
     mode      => '0644',
     subscribe => Exec ['Broker gem dependencies'],
     require   => Exec ['Broker gem dependencies'],
-    ensure    => 'present'
   }
 
   exec { 'Broker gem dependencies':

--- a/manifests/console.pp
+++ b/manifests/console.pp
@@ -208,12 +208,12 @@ class openshift_origin::console {
   # by the following Exec has the appropriate permissions (otherwise
   # it is created as owned by root:root)  
   file { '/var/www/openshift/console/Gemfile.lock':
+    ensure    => 'present',
     owner     => 'apache',
     group     => 'apache',
     mode      => '0644',
     subscribe => Exec ['Console gem dependencies'],
     require   => Exec ['Console gem dependencies'],
-    ensure    => 'present'
   }
 
   exec { 'Console gem dependencies':


### PR DESCRIPTION
...ile.lock

The Console and Broker gem dependencies check (in console.pp and
broker.pp) can create a Gemfile.lock owned by root as a side
effect. This change adds a File resource to both files that subscribes
to the dep check Exec and cleans up Gemfile.lock

Without this change, broker and/or console can fail to run properly
