### PR TITLE
log about .mongo-setup-complete

### DIFF
--- a/templates/mongodb/oo-mongo-setup
+++ b/templates/mongodb/oo-mongo-setup
@@ -91,7 +91,7 @@ end
 
 FileUtils.mkdir_p("/etc/openshift")
 if File.exist?("/etc/openshift/.mongo-setup-complete")
-  $log.info "Mongo has already been setup on this machine. Exiting"
+  $log.info "Mongo has already been setup on this machine. Lock file '/etc/openshift/.mongo-setup-complete' is present. Exiting"
 else
   $log.info "Configuring Mongo DB"
   $log.info "...setup mongo db admin users"


### PR DESCRIPTION
When mongo has already been setup once we have the following message when trying to call it twice:

```
$ /usr/sbin/oo-mongo-setup
I, [2013-05-15T13:09:41.928062 #25353]  INFO -- : Mongo has already been setup on this machine. Exiting
```

It would be useful to inform the user about the presence of the lock file `/etc/openshift/.mongo-setup-complete`.

It would avoid to look at the sources.
