### PR TITLE
Bug 965970 - Fix permissions on /var/named

### DIFF
--- a/manifests/named.pp
+++ b/manifests/named.pp
@@ -48,7 +48,7 @@ class openshift_origin::named {
     owner   => 'named',
     group   => 'named',
     mode    => '0644',
-    require => File['/var/named'],
+    require => File['/var/named/dynamic'],
   }
 
   exec { 'create rndc.key':
@@ -73,7 +73,7 @@ class openshift_origin::named {
 
   file { '/var/named':
     ensure  => directory,
-    owner   => 'named',
+    owner   => 'root',
     group   => 'named',
     mode    => '0750',
     require => Package['bind'],


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=965970

/var/named should be owned by root to prevent AVC denials on bind
restart

Fix requires on dynamic zone, should be /var/named/dynamic and not
/var/named
