### PR TITLE
Fix template path for qpid.

### DIFF
--- a/manifests/qpidd.pp
+++ b/manifests/qpidd.pp
@@ -41,7 +41,7 @@ class openshift_origin::qpidd {
   )
 
   file { '/etc/qpidd.conf':
-    content => template('openshift/qpid/qpidd.conf.erb'),
+    content => template('openshift_origin/qpid/qpidd.conf.erb'),
     owner   => 'root',
     group   => 'root',
     mode    => '0644',


### PR DESCRIPTION
Trying to enable 'configure_qpid' with the latest Puppet module code fails because of an old template reference.
