### PR TITLE
Change vagrant file to clone master branch

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,15 +8,17 @@ Vagrant::Config.run do |config|
   config.vm.forward_port 443, 8443
   config.vm.forward_port 53, 53
   config.vm.host_name = 'broker.example.com'
-  
+
   config.vm.share_folder "manifests", "/home/vagrant/manifests", "manifests"
   config.vm.provision :shell, :inline => %{ \
     sudo bash -x /home/vagrant/manifests/f19_patches.sh | tee -a /var/log/origin-setup.log; \
     touch /var/log/origin-setup.log; \
     sudo /bin/puppet apply --verbose /home/vagrant/manifests/init.pp      | tee -a /var/log/origin-setup.log; \
-    sudo /bin/systemctl restart  network.service                   | tee -a /var/log/origin-setup.log; \
-    sudo /bin/puppet module uninstall openshift/openshift_origin          | tee -a /var/log/origin-setup.log; \
-    sudo /bin/puppet module install openshift/openshift_origin            | tee -a /var/log/origin-setup.log; \
+    sudo /bin/systemctl restart  network.service                          | tee -a /var/log/origin-setup.log; \
+    sudo /bin/rm -rf /etc/puppet/modules/* ; \
+    sudo /bin/puppet module install puppetlabs/stdlib                     | tee -a /var/log/origin-setup.log; \
+    sudo /bin/puppet module install puppetlabs/ntp                        | tee -a /var/log/origin-setup.log; \
+    sudo /bin/git clone git://github.com/openshift/puppet-openshift_origin.git /etc/puppet/modules/openshift_origin | tee -a /var/log/origin-setup.log; \
     sudo /bin/puppet apply --verbose /home/vagrant/manifests/configure.pp | tee -a /var/log/origin-setup.log; \
     sudo /bin/systemctl restart  activemq.service                  | tee -a /var/log/origin-setup.log; \
     sudo /bin/systemctl restart  cgconfig.service                  | tee -a /var/log/origin-setup.log; \


### PR DESCRIPTION
The current vagrant file installs the openshift module from the forge.
We should be testing the master branch rather than the current module on
the forge.
