### PR TITLE
Updating configure.pp to remove error from current state of vagrant inst...

### DIFF
--- a/test/manifests/configure.pp
+++ b/test/manifests/configure.pp
@@ -17,6 +17,5 @@ class { 'openshift_origin' :
   configure_node             => true,
   development_mode           => true,
   configure_cgroups          => true,
-  use_v2_carts               => true,
   eth_device => 'p2p1'
 }


### PR DESCRIPTION
...all

The following line.. 

curl -s https://nodeload.github.com/openshift/puppet-openshift_origin/legacy.tar.gz/master | tar zxf - --strip 1 '**/test' && mv test origin_vagrant

from.. 

http://openshift.github.io/origin/file.install_origin_using_vagrant.html

pulls this file and causes the 'vagrant up' process to fail if use_v2_cart flag is present.
