### PR TITLE
Better resolution of IPaddress for oo-mongo-setup script

### DIFF
--- a/templates/mongodb/oo-mongo-setup
+++ b/templates/mongodb/oo-mongo-setup
@@ -101,7 +101,7 @@ else
 
   begin
     hostname = Socket.gethostname
-    ipaddr   = IPSocket.getaddress(hostname)
+    ipaddr   = Socket::getaddrinfo(hostname,nil,Socket::AF_INET)[0][3]
   rescue
     addresses = `ip addr`.scan(/inet ([\d]+\.[\d]+\.[\d]+\.[\d]+)/).flatten
     ipaddr = (addresses - ["127.0.0.1"]).first


### PR DESCRIPTION
IPSocket.getaddress(hostname) has potential to return IPv6 address which mongo does not understand.
