### PR TITLE
Fixing version of jenkins used. [test]

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -428,11 +428,18 @@ class openshift_origin (
   }
 
   if ($set_sebooleans == true) {
+    file { '/etc/openshift':
+      ensure  => "directory",
+      owner   => 'root',
+      group   => 'root',
+    }
+
     file { '/etc/openshift/.selinux-setup-complete':
       content => '',
       owner   => 'root',
       group   => 'root',
       mode    => '0644',
+      require => File['/etc/openshift'],
     }
   }
 
@@ -443,9 +450,9 @@ class openshift_origin (
   if $install_client_tools == true {
     # Install rhc tools. On RHEL/CentOS, this will install under ruby 1.8 environment
     ensure_resource('package', 'rhc', {
-      ensure  => present,
-      require => Yumrepo[openshift-origin],
-    }
+        ensure  => present,
+        require => Yumrepo[openshift-origin],
+      }
     )
 
     file { '/etc/openshift/express.conf':

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -503,6 +503,24 @@ class openshift_origin::node {
     require => File['create node setting markers dir']
   }
 
+  package { 'jenkins':
+    ensure  => "1.510-1.1",
+    require => [
+      Yumrepo['jenkins'],
+    ]
+  }
+
+  package { 'yum-plugin-versionlock':
+    ensure  => latest,
+  }
+
+  exec { '/usr/bin/yum versionlock jenkins':
+    require => [
+      Package['jenkins'],
+      Package['yum-plugin-versionlock'],
+    ]
+  }
+
   package { [
     'openshift-origin-cartridge-10gen-mms-agent',
     'openshift-origin-cartridge-cron',
@@ -523,6 +541,7 @@ class openshift_origin::node {
     require => [
       Yumrepo[openshift-origin],
       Yumrepo[openshift-origin-deps],
+      Package['jenkins'],
     ],
     notify => Exec['oo-admin-cartridge'],
   }


### PR DESCRIPTION
The OpenShift jenkins plugin is not compatible with new versions of jenkins.
Fixes jenkins error in runtime extended tests.
