### PR TITLE
Change the DNS port forwared in Vagrant to 5353 and added UDP protocol

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -6,9 +6,9 @@ Vagrant::Config.run do |config|
   config.vm.box_url = 'http://www.krishnaraman.net/downloads/fedora-19.box'
   config.vm.forward_port 80, 8080
   config.vm.forward_port 443, 8443
-  config.vm.forward_port 53, 53
+  config.vm.forward_port 53, 5353, :protocol => :udp
   config.vm.host_name = 'broker.example.com'
-  
+
   config.vm.share_folder "manifests", "/home/vagrant/manifests", "manifests"
   config.vm.provision :shell, :inline => %{ \
     touch /var/log/origin-setup.log; \


### PR DESCRIPTION
VirtualBox will not allow to forward ports <1024 in host machine. For that the DNS port should be changed to '5353' instead of '53' and the protocol changed to UDP instead of TCP (which is the default).

This will allow to use `dnsmasq` on the host machine to proxy openshift applications domains to the host machine.

http://mfojtik.im/howto-make-dns-working-for-openshift-in-vagrant
