### PR TITLE
<puppet-openshift_origin> - Fix extraneous require

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -563,7 +563,6 @@ class openshift_origin (
       exec{ "Register host ${::hostname} with IP ${::ipaddress} with named":
         command => "/usr/sbin/oo-register-dns -h ${::hostname} -n ${::ipaddress}",
         require => [
-          Package['openshift-origin-msg-node-mcollective'],
           Package['facter'],
           Package['openshift-origin-broker-util'],
           Service['named']


### PR DESCRIPTION
Remove a require for Package['openshift-origin-msg-node-mcollective']
for an exec that is only executed on a broker.
