### PR TITLE
activemq.xml.erb: Restore corrupted comment

### DIFF
--- a/templates/activemq/activemq.xml.erb
+++ b/templates/activemq/activemq.xml.erb
@@ -71,7 +71,7 @@
 
         <!--
             The managementContext is used to configure how ActiveMQ is exposed in
-                                                                         ed by
+            JMX. By default, ActiveMQ uses the MBean server that is started by
             the JVM. For more information, see:
 
             http://activemq.apache.org/jmx.html


### PR DESCRIPTION
Fix a comment that was partially blanked out when activemq.xml.erb was first added.
