### PR TITLE
Fixes to be compatible with changes on master

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -951,7 +951,7 @@ class openshift_origin::broker {
   if !defined(File['mcollective client config']) {
     file { 'mcollective client config':
       ensure  => present,
-      path    => '/etc/mcollective/client.cfg',
+      path    => $::openshift_origin::mcollective_client_cfg,
       content => template('openshift_origin/mcollective-client.cfg.erb'),
       owner   => 'root',
       group   => 'root',
@@ -963,7 +963,7 @@ class openshift_origin::broker {
   if !defined(File['mcollective server config']) {
     file { 'mcollective server config':
       ensure  => present,
-      path    => '/etc/mcollective/server.cfg',
+      path    => $::openshift_origin::mcollective_server_cfg,
       content => template('openshift_origin/mcollective-server.cfg.erb'),
       owner   => 'root',
       group   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -273,6 +273,21 @@ class openshift_origin (
     'Fedora' => '/usr/bin/echo',
     default  => '/bin/echo',
   }
+  
+  $mcollective_client_cfg = $::operatingsystem ? {
+    'Fedora' => '/etc/mcollective/client.cfg',
+    default  => '/opt/rh/ruby193/root/etc/mcollective/client.cfg',
+  }
+  
+  $mcollective_server_cfg = $::operatingsystem ? {
+    'Fedora' => '/etc/mcollective/server.cfg',
+    default  => '/opt/rh/ruby193/root/etc/mcollective/server.cfg',
+  }
+
+  $mcollective_facts_yaml = $::operatingsystem ? {
+    'Fedora' => '/etc/mcollective/facts.yaml',
+    default  => '/opt/rh/ruby193/root/etc/mcollective/facts.yaml',
+  }
 
   if $configure_ntp == true {
     include openshift_origin::ntpd
@@ -381,10 +396,7 @@ class openshift_origin (
   ensure_resource('package', 'policycoreutils', {
     }
   )
-  ensure_resource('package', 'mcollective', {
-      require => Yumrepo['openshift-origin-deps'],
-    }
-  )
+  
   ensure_resource('package', 'httpd', {
     }
   )
@@ -397,6 +409,11 @@ class openshift_origin (
   )
 
   if $::operatingsystem == "Fedora" {
+    ensure_resource('package', 'mcollective', {
+        require => Yumrepo['openshift-origin-deps'],
+      }
+    )
+    
     ensure_resource('package', 'ruby-devel', {
         ensure  => present,
       }
@@ -408,6 +425,12 @@ class openshift_origin (
       }
     )
   } else {
+    ensure_resource('package', 'ruby193-mcollective', {
+        require => Yumrepo['openshift-origin-deps'],
+        alias   => 'mcollective'
+      }
+    )
+    
     ensure_resource('package', 'ruby193-ruby-devel', {
         ensure => present,
         alias => 'ruby-devel',

--- a/templates/broker/msg-broker-mcollective.conf.erb
+++ b/templates/broker/msg-broker-mcollective.conf.erb
@@ -2,7 +2,7 @@ MCOLLECTIVE_DISCTIMEOUT=5
 MCOLLECTIVE_TIMEOUT=60
 MCOLLECTIVE_VERBOSE=0
 MCOLLECTIVE_PROGRESS_BAR=0
-MCOLLECTIVE_CONFIG="/etc/mcollective/client.cfg"
+MCOLLECTIVE_CONFIG="<%= scope.lookupvar('::openshift_origin::mcollective_client_cfg') %>"
                                                                                                                                                                                                                                                                                   
 DISTRICTS_ENABLED=false
 DISTRICTS_REQUIRE_FOR_APP_CREATE=false

--- a/templates/mcollective-server.cfg.erb
+++ b/templates/mcollective-server.cfg.erb
@@ -44,4 +44,4 @@ plugin.qpid.timeout=5
 
 # Facts
 factsource = yaml
-plugin.yaml = /etc/mcollective/facts.yaml
+plugin.yaml = <%= scope.lookupvar('::openshift_origin::mcollective_facts_yaml') %>

--- a/templates/node/node.conf.erb
+++ b/templates/node/node.conf.erb
@@ -37,4 +37,6 @@ PLATFORM_LOG_LEVEL=DEBUG
 PLATFORM_TRACE_LOG_FILE=/var/log/openshift/node/platform-trace.log
 PLATFORM_TRACE_LOG_LEVEL=DEBUG
 
+OPENSHIFT_FRONTEND_HTTP_PLUGINS=openshift-origin-frontend-apache-mod-rewrite,openshift-origin-frontend-nodejs-websocket
+
 CONTAINERIZATION_PLUGIN=openshift-origin-container-<%= scope.lookupvar('::openshift_origin::node_container')%>


### PR DESCRIPTION
Use ruby193-mcollective on RHEL.
Add jbossas cartridge on Fedora 19.
Add support for http-proxy and websocket-proxy plugins.
