### PR TITLE
custom_shell.pp: Rephrased the comments in the header

### DIFF
--- a/manifests/custom_shell.pp
+++ b/manifests/custom_shell.pp
@@ -1,6 +1,6 @@
-# == Class: openshift_origin::mongo
+# == Class: openshift_origin::custom_shell
 #
-# Manage MongoDB for OpenShift Origin.
+# Manage Custom Shell in Fedora for OpenShift Origin.
 #
 # === Parameters
 #
@@ -8,7 +8,7 @@
 #
 # === Examples
 #
-#  include openshift_origin::mongo
+#  include openshift_origin::params
 #
 # === Copyright
 #
@@ -31,7 +31,7 @@
 #
 class openshift_origin::custom_shell {
   include openshift_origin::params
-  
+
   if ($::operatingsystem != 'Fedora') {
     fail 'Custom OpenShift Origin shell is only available on Fedora systems'
   }
@@ -56,7 +56,7 @@ class openshift_origin::custom_shell {
     group   => 'root',
     mode    => '0644',
   }
-  
+
   file { '/usr/bin/oo-login':
     ensure  => present,
     path    => '/usr/bin/oo-login',


### PR DESCRIPTION
This patch is created to fix the cut&paste from the mongo module
to the custom_shell file.

In fact, before this patch, there was in both files the informations
about the mongodb module and not the right info for custom_shell.

And it also removes the trailing spaces.
