### PR TITLE
Updated to create /etc/openshift/htpasswd if it doesn't exist.

### DIFF
--- a/manifests/plugins/auth/htpasswd.pp
+++ b/manifests/plugins/auth/htpasswd.pp
@@ -26,7 +26,7 @@ class openshift_origin::plugins::auth::htpasswd {
   }
 
   exec { 'set first OpenShift user password':
-    command     => "/usr/bin/htpasswd -b /etc/openshift/htpasswd ${::openshift_origin::openshift_user1} ${::openshift_origin::openshift_password1}",
+    command     => "/usr/bin/htpasswd -bc /etc/openshift/htpasswd ${::openshift_origin::openshift_user1} ${::openshift_origin::openshift_password1}",
     require => [
       Package['httpd-tools'],
       File['htpasswd'],


### PR DESCRIPTION
/etc/openshift/htpasswd is failing to be created with batch only flag (-b) set because it is attempting to batch add on a non-existent file.  Adding the -c creates the file if it doesn't exist, and still allows for the batch processing to occur.
