### PR TITLE
Correction to PR#117

### DIFF
--- a/manifests/plugins/auth/htpasswd.pp
+++ b/manifests/plugins/auth/htpasswd.pp
@@ -26,7 +26,7 @@ class openshift_origin::plugins::auth::htpasswd {
   }
 
   exec { 'create /etc/openshift dir and set first OpenShift user password':
-    command  => "/usr/bin/mkdir -p /etc/openshift && /usr/bin/htpasswd -b /etc/openshift/htpasswd ${::openshift_origin::openshift_user1} ${::openshift_origin::openshift_password1}",
+    command  => "/usr/bin/mkdir -p /etc/openshift && /usr/bin/htpasswd -bc /etc/openshift/htpasswd ${::openshift_origin::openshift_user1} ${::openshift_origin::openshift_password1}",
     require  => [
       Package['httpd-tools'],
       File['htpasswd'],


### PR DESCRIPTION
Dude here.  PR #117 was a false positive.  Apologies.

This PR addresses the /etc/openshift/htpasswd file creation process.

If an AIO install is under-weigh, and broker_auth_plugin => 'htpasswd' is set in configure_origin.pp, the htpasswd file creation will fail. Although, If the user waits long enough for broker.pp to kick in -- it will create the directory (for /etc/openshift/server_pub.pem creation.)  This requires the user to stop the first install, and re-run the puppet apply.

Naturally, the file isn't created on the first pass (even if the -bc flags are invoked) because the /etc/openshift directory doesn't exist at this point in time.  

This PR addresses this issue by creating /etc/openshift ahead of time for htpasswd.pp to execute cleanly.
