### PR TITLE
Add a zone for OpenShift infrastructure if requested

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -300,6 +300,46 @@
 #   Setup DNS entries for this host in a locally installed bind DNS instance.
 #   Default: false
 #
+# [*dns_infrastructure_zone*]
+#   The name of a zone to create which will contain OpenShift infrastructure
+#
+#   If this is unset then no infrastructure zone or other artifacts will be
+#   created.
+
+#   Default: ''
+#
+# [*dns_infrastructure_key*]
+#   An HMAC-MD5 dnssec symmetric key which will grant update access to the
+#   infrastucture zone resource records.
+#
+#   This is ignored unless _dns_infrastructure_zone_ is set.
+#
+#   Default: ''
+#
+# [*dns_infrastructure_names*]
+#   An array of hashes containing hostname and IP Address pairs to populate
+#   the infrastructure zone.
+#
+#   This value is ignored unless _dns_infrastructure_zone_ is set.
+#
+#   Hostnames can be simple names or fully qualified domain name (FQDN).
+#
+#   Simple names will be placed in the _dns_infrastructure_zone_.
+#   Matching FQDNs will be placed in the _dns_infrastructure_zone.
+#   Hostnames anchored with a dot (.) will be added verbatim.
+# 
+#   Default: []
+#
+#   Example:
+#     $dns_infrastructure_names = [
+#       {hostname => '10.0.0.1', ipaddr => 'broker1'},
+#       {hostname => '10.0.0.2', ipaddr => 'data1'},
+#       {hostname => '10.0.0.3', ipaddr => 'message1'},
+#       {hostname => '10.0.0.11', ipaddr => 'node1'},       
+#       {hostname => '10.0.0.12', ipaddr => 'node2'},       
+#       {hostname => '10.0.0.13', ipaddr => 'node3'},       
+#     ]
+#
 # [*firewall_provider*]
 #   Select the firewall provider to configure OpenShift with.
 #   Options:
@@ -426,6 +466,9 @@ class openshift_origin (
   $conf_named_upstream_dns              = ['8.8.8.8'],
   $install_login_shell                  = false,
   $register_host_with_named             = false,
+  $dns_infrastructure_zone              = '',
+  $dns_infrastructure_key               = '',
+  $dns_infrastructure_names             = [],
   $firewall_provider                    = 'iptables',
   $install_cartridges                   = ['10gen-mms-agent','cron','diy','haproxy','mongodb',
                                            'nodejs','perl','php','phpmyadmin','postgresql',

--- a/templates/named/named.conf.erb
+++ b/templates/named/named.conf.erb
@@ -47,3 +47,6 @@ zone "<%= scope.lookupvar('::openshift_origin::domain') %>" IN {
     file "dynamic/<%= scope.lookupvar('::openshift_origin::domain') %>.db";
     allow-update { key <%= scope.lookupvar('::openshift_origin::domain') %> ; } ;
 };
+
+// create a place for openshift infrastructure ip/name mapping
+include "oo_infrastructure.conf";

--- a/templates/named/oo_infrastructure.conf.erb
+++ b/templates/named/oo_infrastructure.conf.erb
@@ -1,0 +1,8 @@
+// define a zone for infrastructure hosts
+
+zone "<%= scope.lookupvar('::openshift_origin::dns_infrastructure_zone') %>" IN {
+    type master;
+    file "dynamic/<%= scope.lookupvar('::openshift_origin::dns_infrastructure_zone') %>.db";
+    allow-update { key <%= scope.lookupvar('::openshift_origin::dns_infrastructure_zone') %> ; } ;
+};
+

--- a/templates/named/oo_infrastructure.db.erb
+++ b/templates/named/oo_infrastructure.db.erb
@@ -1,0 +1,17 @@
+$ORIGIN .
+$TTL 1800
+<%= scope.lookupvar('::openshift_origin::dns_infrastructure_zone') %> IN SOA ns1.<%= scope.lookupvar('::openshift_origin::dns_infrastructure_zone') %>. hostmaster.<%= scope.lookupvar('::openshift_origin::dns_infrastructure_zone') %>. (
+                         2011112904 ; serial
+                         60         ; refresh (1 minute)
+                         15         ; retry (15 seconds)
+                         1800       ; expire (30 minutes)
+                         10         ; minimum (10 seconds)
+                          )
+                     NS ns1.<%= scope.lookupvar('::openshift_origin::dns_infrastructure_zone') %>.
+$ORIGIN <%= scope.lookupvar('::openshift_origin::dns_infrastructure_zone') %>.
+ns1	IN	A        <%= scope.lookupvar('::ipaddress') %>
+
+;; add the remaining hosts
+<%- scope.lookupvar('::openshift_origin::dns_infrastructure_names').each do |rr| -%>
+<%= rr['hostname'].gsub(/\.#{scope.lookupvar('::openshift_origin::dns_infrastructure_zone')}$/, '') -%>	IN	A	<%= rr['ipaddr'] %>
+<%- end -%>

--- a/templates/named/oo_infrastructure_key.erb
+++ b/templates/named/oo_infrastructure_key.erb
@@ -1,0 +1,4 @@
+key <%= scope.lookupvar('::openshift_origin::dns_infrastructure_zone') %> {
+  algorithm HMAC-MD5;
+  secret "<%= scope.lookupvar('::openshift_origin::dns_infrastructure_key') %>";
+};


### PR DESCRIPTION
This change allows the openshift_origin class to also create a separate DNS zone for the OpenShift infrastructure hosts.  The caller must provide the zone name, a zone update key (if dynamic updates are enabled) and a set of
hostname/ipaddress pairs for the infrastructure hosts.

This change adds 3 arguments to the openshift_origin class:
- **dns_infrastructure_zone**
  The zone which will contain the OpenShift infrastructure hosts
- **dns_infrastructure_key**
  The DNS update key string
- **dns_infrastructure_names**
  A list of hostname/ipaddress pairs to use to populate the infrastructure zone.

> dns_infrastructure_names => [
> 
> > {hostname => 'broker1', ipaddr => '10.0.0.1'},
> >  {hostname => 'data1', ipaddr => '10.0.0.2'},
> >  {hostname => 'message1', ipaddr => '10.0.0.3'},
> >  {hostname => 'node1', ipaddr => '10.0.0.11'},
> > ],
