### PR TITLE
Use mount point rather than directory for quota

### DIFF
--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -60,7 +60,8 @@ class openshift_origin::node {
   exec { 'Initialize quota DB':
     command => '/usr/sbin/oo-init-quota',
     require => Package['openshift-origin-node-util'],
-    unless  => '/usr/bin/quota -f /var/lib/openshift/ -q 2>/dev/null',
+    path    => ['/usr/sbin', '/usr/bin', '/sbin', '/bin'],
+    unless  => '/usr/bin/quota -f $(df /var/lib/openshift/ | tail -1 | tr -s \' \' | cut -d\' \' -f 6 | sort -u) -q 2>/dev/null',
   }
   
   augeas { 'Tune Sysctl knobs':


### PR DESCRIPTION
Use mountpoint for quota rather than directory in filesystem.  "quota -f"
expects a mount point or device so grab that from "df".  Series of shell
commands taken from oo-init-quota.
