### PR TITLE
Open firewall for DNS on both TCP and UDP

### DIFF
--- a/manifests/named.pp
+++ b/manifests/named.pp
@@ -83,8 +83,14 @@ class openshift_origin::named {
     require => Package['bind'],
   }
 
-  firewall{ 'dns':
-    service => 'dns',
+  firewall{ 'dns-tcp':
+    port     => 53,
+    protocol => 'tcp',
+  }
+
+  firewall{ 'dns-udp':
+    port     => 53,
+    protocol => 'udp',
   }
 
   exec { 'named restorecon':


### PR DESCRIPTION
nsupdate uses UDP by default unless the request is too large.  Open DNS to both
TCP and UDP rather than just TCP.
