### PR TITLE
Use "service" to start and stop mongod on Red Hat

### DIFF
--- a/manifests/mongo.pp
+++ b/manifests/mongo.pp
@@ -33,13 +33,13 @@ class openshift_origin::mongo {
     ],
   }
 
+  $openshift_init_provider = $::operatingsystem ? {
+    'Fedora' => 'systemd',
+    'CentOS' => 'redhat',
+    default  => 'redhat',
+  }
+
   if $openshift_origin::configure_mongodb == 'delayed' {
-    $openshift_init_provider = $::operatingsystem ? {
-      'Fedora' => 'systemd',
-      'CentOS' => 'redhat',
-      default  => 'redhat',
-    }
-    
     if $openshift_init_provider == 'systemd' {
       file { 'mongo setup service':
         ensure  => present,

--- a/templates/mongodb/oo-mongo-setup
+++ b/templates/mongodb/oo-mongo-setup
@@ -60,7 +60,11 @@ def run(cmd)
 end
 
 def stop_mongo
+<% if scope.lookupvar("openshift_origin::mongo::openshift_init_provider") == "systemd" %>
   unless File.exist?("/usr/bin/systemctl") && run("/usr/bin/systemctl stop mongod.service") == 0
+<% else %>
+  unless run("/sbin/service mongod stop") == 0
+<% end %>
     run "/usr/bin/pkill -u mongodb"
 
     $log.debug("Repair mongodb database if needed...")
@@ -86,7 +90,11 @@ end
 
 def start_mongo
   $log.debug "Initializing mongodb database"
+<% if scope.lookupvar("openshift_origin::mongo::openshift_init_provider") == "systemd" %>
   unless File.exist?("/usr/bin/systemctl") && run("/usr/bin/systemctl start mongod.service") == 0
+<% else %>
+  unless run("/sbin/service mongod start") == 0
+<% end %>
     run "/bin/su -c 'mongod -f /etc/mongodb.conf' --shell /bin/bash mongodb"
   end
   while run('/bin/fgrep "[initandlisten] waiting for connections" /var/log/mongodb/mongodb.log') != 0 do


### PR DESCRIPTION
RHEL/CentOS doesn't have systemd yet; use "service" to start and stop mongod
when the openshift_init_provider is set to "redhat".
