### PR TITLE
moved cgroup setup for non-Fedora to node.pp

### DIFF
--- a/manifests/plugins/container/selinux.pp
+++ b/manifests/plugins/container/selinux.pp
@@ -203,22 +203,4 @@ class openshift_origin::plugins::container::selinux {
     require => Package['pam_openshift'],
   }
   
-  if $::operatingsystem != 'Fedora' {
-    file { '/etc/cgconfig.conf':
-      content => template('openshift_origin/plugins/container/cgconfig.conf.erb'),
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
-      notify  => Exec['prepare cgroups']
-    }
-    
-    exec { 'prepare cgroups':
-      command     => '/sbin/restorecon -rv /etc/cgconfig.conf; mkdir -p /cgroup; restorecon -rv /cgroup',
-      refreshonly => true
-    }
-    
-    service { ['cgconfig', 'cgred']:
-      enable => true
-    }
-  }
 }


### PR DESCRIPTION
Cgroup setup was related to configuring SELinux.  It's really more general than that.

This change moves the cgroup setup for systems which use init/upstart to the general node configuration.

Systems which use systemd have cgroups integrated and don't require special services running to operate as an openshift node. 
