### PR TITLE
Bug 1051151 - Removed Node gem dependency for auth component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .vagrant
 metadata.json
 *~

--- a/manifests/plugins/auth/htpasswd.pp
+++ b/manifests/plugins/auth/htpasswd.pp
@@ -23,7 +23,7 @@ class openshift_origin::plugins::auth::htpasswd {
   file { 'htpasswd':
     path     => "/etc/openshift/htpasswd",
     ensure   => file,
-    require  => Package['rubygem-openshift-origin-node'],
+    require  => Package['openshift-origin-broker'],
   }
 
   $mkdir = $::operatingsystem ? {


### PR DESCRIPTION
Replaced Node gem requirement with broker package so that auth can be set up on the Broker even when a Node will not be installed on the same system.
