### PR TITLE
Fixes Augeas to Properly Configure Sysctl

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -555,22 +555,5 @@ class openshift_origin (
       enable => true,
     }
   }
-  $node_shmmax_default = $::architecture ? {
-    'x86_64' => 68719476736,
-    default  => 33554432,
-  }
-  $_node_shmmax = $node_shmax ? {
-    undef   => $node_shmmax_default,
-    default => $node_shmmax,
-  }
-
-  $node_shmall_default = $::architecture ? {
-    'x86_64' => 4294967296,
-    default  => 2097152,
-  }
-  $_node_shmall = $node_shmall ? {
-    undef   => $node_shmall_default,
-    default => $node_shmall,
-  }
 
 }

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -83,9 +83,9 @@ class openshift_origin::node {
       "set net.ipv4.conf.all.route_localnet 1",
       
       #Shared memory limits
-      "set kernel.shmall ${::openshift_origin::_node_shmall}",
-      "set kernel.shmmax ${::openshift_origin::_node_shmmax}",
-      
+      "set kernel.shmall ${::openshift_origin::params::_node_shmall}",
+      "set kernel.shmmax ${::openshift_origin::params::_node_shmmax}",
+
       #IPC Message queue limits
       "set kernel.msgmnb 65536",
       "set kernel.msgmax 65536",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -104,4 +104,22 @@ class openshift_origin::params {
     'Fedora' => ['iptables', 'iptables-services'],
     default  => ['iptables'],
   }
+
+  $node_shmmax_default = $::architecture ? {
+    'x86_64' => 68719476736,
+    default  => 33554432,
+  }
+  $_node_shmmax = $::openshift_origin::node_shmmax ? {
+    undef   => $node_shmmax_default,
+    default => $::openshift_origin::node_shmmax,
+  }
+
+  $node_shmall_default = $::architecture ? {
+    'x86_64' => 4294967296,
+    default  => 2097152,
+  }
+  $_node_shmall = $::openshift_origin::node_shmall ? {
+    undef   => $node_shmall_default,
+    default => $::openshift_origin::node_shmall,
+  }
 }


### PR DESCRIPTION
The following puppet agent error was observed on nodes:

/Stage[main]/Openshift_origin::Node/Augeas[Tune Sysctl knobs]:
Could not evaluate: missing string argument 2 for set

This prevented Augeas from configuring the necessary sysctl
parameters.
