### PR TITLE
Fixes NetworkManager Installation Error

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -569,8 +569,12 @@ class openshift_origin (
   class{ 'openshift_origin::update_resolv_conf': }
 
   if $::operatingsystem == 'Fedora' {
+    package { 'NetworkManager':
+      ensure  => present,
+    }
     service { 'NetworkManager-wait-online':
-      enable => true,
+      require => Package['NetworkManager'],
+      enable  => true,
     }
   }
 


### PR DESCRIPTION
Previously, the puppet agent installation was failing due to the
NetworkManager-Wait-online service not being installed:

Error: Could not enable NetworkManager-wait-online: Execution of
'/sbin/chkconfig NetworkManager-wait-online on' returned 1: error
reading information on service NetworkManager-wait-online:
No such file or directory

This service appears to be unneeded for Fedora 19.
