### PR TITLE
Ensures rubygem-bundler on Fedora

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -74,6 +74,11 @@ class openshift_origin::params {
     'Fedora' => '/usr/bin/echo',
     default  => '/bin/echo',
   }
+
+  $ruby_bundler_pkg = $::operatingsystem ? {
+    'Fedora' => 'rubygem-bundler',
+    default  => 'ruby193-rubygem-bundler',
+  }
   
   $ruby_scl_prefix = $::operatingsystem ? {
     'Fedora' => '',


### PR DESCRIPTION
Previously, Ruby bundler commands would fail because the
rubygem-bundler package was not being installed (as required) on
Fedora systems.
