### PR TITLE
Fixes ActiveMQ Service Startup

### DIFF
--- a/manifests/activemq.pp
+++ b/manifests/activemq.pp
@@ -35,6 +35,7 @@ class openshift_origin::activemq {
       group   => 'root',
       mode    => '0444',
       require => Package['activemq'],
+      notify  => Service['activemq'],
     }
   }
 
@@ -53,6 +54,7 @@ class openshift_origin::activemq {
     group   => 'root',
     mode    => '0444',
     require => Package['activemq'],
+    notify  => Service['activemq'],
   }
 
   file { 'jetty.xml config':
@@ -62,6 +64,7 @@ class openshift_origin::activemq {
     group   => 'root',
     mode    => '0444',
     require => Package['activemq'],
+    notify  => Service['activemq'],
   }
 
   file { 'jetty-realm.properties config':
@@ -71,6 +74,7 @@ class openshift_origin::activemq {
     group   => 'root',
     mode    => '0444',
     require => Package['activemq'],
+    notify  => Service['activemq'],
   }
 
   ensure_resource('service', 'activemq', {


### PR DESCRIPTION
Previously, ActiveMQ was in a "down" state after the successful
completion of a puppet agent run.  This is because the service was
not being restarted after modifying the necessary configuration
files.  By adding a notify => activemq service to config
files, the service is now being restarted by puppet.
