### PR TITLE
Adds Firewall Rule for Broker API

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -181,4 +181,9 @@ class openshift_origin::broker {
       service => 'https',
     }
   )
+
+  ensure_resource( 'firewall', 'webcache', {
+      service => 'webcache',
+    }
+  )
 }

--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -82,17 +82,19 @@ define firewall( $service=undef, $port=undef, $protocol=undef ) {
         }
       } else {
         $sport = $service ? {
-          'http'  => '80',
-          'https' => '443',
-          'ssh'   => '22',
-          'dns'   => '53',
+          'http'     => '80',
+          'https'    => '443',
+          'ssh'      => '22',
+          'dns'      => '53',
+          'webcache' => '8080',
         }
       
         $sprotocol = $service ? {
-          'http'  => 'tcp',
-          'https' => 'tcp',
-          'ssh'   => 'tcp',
-          'dns'   => 'tcp',
+          'http'     => 'tcp',
+          'https'    => 'tcp',
+          'ssh'      => 'tcp',
+          'dns'      => 'tcp',
+          'webcache' => 'tcp',
         }
       
         exec { "Open port ${sport}:${sprotocol} for service ${service}":


### PR DESCRIPTION
Previously, the firewall was not allowing traffic to the Broker
API (TCP port 8080).  Therefore, implementations would only
function properly when the broker was listening on the loopback
address. This is not preferable for real world multi-node
deployments.

This patch configures iptables to allow TCP 8080 through the
iptables firewall.
