### PR TITLE
Adds Support for Managing the Broker/Console API Endpoint Address

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -228,6 +228,16 @@ List of upstream DNS servers to use when installing named on this node.
 
 Default: ['8.8.8.8']
 
+==== broker_listen_ip
+IP address the Broker API endpoint listens on.
+
+Default: '127.0.0.1'
+
+==== console_listen_ip
+IP address the Broker Web Console listens on.
+
+Default: $broker_listen_ip
+
 ==== broker_ip_addr
 This is used for the node to record its broker. Also is the default
 for the nameserver IP if none is given.

--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -116,6 +116,26 @@ class openshift_origin::broker {
     require => Package['openshift-origin-broker'],
   }
 
+  file { 'openshift httpd broker.conf':
+    path    => '/var/www/openshift/broker/httpd/broker.conf',
+    content => template('openshift_origin/broker/httpd_broker.conf.erb'),
+    owner   => 'apache',
+    group   => 'apache',
+    mode    => '0644',
+    require => Package['openshift-origin-broker'],
+    notify  => Service['openshift-broker'],
+  }
+
+  file { 'openshift httpd broker proxy.conf':
+    path    => '/etc/httpd/conf.d/000002_openshift_origin_broker_proxy.conf',
+    content => template('openshift_origin/broker/proxy.conf.erb'),
+    owner   => 'apache',
+    group   => 'apache',
+    mode    => '0644',
+    require => Package['openshift-origin-broker'],
+    notify  => Service['openshift-broker'],
+  }
+
   if $::openshift_origin::development_mode == true {
     file { 'openshift broker-dev.conf':
       path    => '/etc/openshift/broker-dev.conf',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -238,6 +238,14 @@
 #   List of all gear sizes that newly created users will be able to create
 #   Default: ['small']
 #
+# [*broker_listen_ip*]
+#   IP address used by the Broker API endpoint to listen on.
+#   Default: '127.0.0.1'
+#
+# [*console_listen_ip*]
+#   IP address used by the Broker Web Console to listen on.
+#   Default: $broker_listen_ip
+#
 # [*broker_dns_plugin*]
 #   DNS plugin used by the broker to register application DNS entries.
 #   Options:
@@ -507,6 +515,8 @@ class openshift_origin (
   $conf_valid_gear_sizes                = ['small'],
   $conf_default_gear_capabilities       = ['small'],
   $conf_default_gear_size               = 'small',
+  $broker_listen_ip                     = '127.0.0.1',
+  $console_listen_ip                    = $broker_listen_ip,
   $broker_dns_plugin                    = 'nsupdate',
   $broker_auth_plugin                   = 'htpasswd',
   $broker_krb_service_name              = '',

--- a/templates/broker/httpd_broker.conf.erb
+++ b/templates/broker/httpd_broker.conf.erb
@@ -1,0 +1,17 @@
+# This file is managed by Puppet.
+ServerRoot "/var/www/openshift/broker/httpd"
+DocumentRoot "/var/www/openshift/broker/public"
+Listen <%= scope.lookupvar('::openshift_origin::broker_listen_ip') %>:8080
+User apache
+Group apache
+
+include /etc/httpd/conf.d/passenger.conf
+PassengerUser apache
+PassengerMaxPoolSize 80
+PassengerMinInstances 2
+PassengerPreStart http://<%= scope.lookupvar('::openshift_origin::broker_listen_ip') %>:8080/broker/rest/api.json
+PassengerUseGlobalQueue off
+
+<Directory /var/www/openshift/broker/public>
+    Options -MultiViews
+</Directory>

--- a/templates/broker/proxy.conf.erb
+++ b/templates/broker/proxy.conf.erb
@@ -1,0 +1,49 @@
+# This file is managed by Puppet
+#
+# This configuration is to proxy to an OpenShift broker
+# (and optional developer console) running in a separate
+# httpd instance.
+#
+# Passenger will sever connections, returning 500
+# exceptions, when graceful restarting under load.
+
+<Directory />
+    Options FollowSymLinks
+    AllowOverride None
+</Directory>
+
+<VirtualHost *:80>
+  # ServerName we will inherit from other config;
+  # ServerAlias is to make sure "localhost" traffic goes here regardless.
+  ServerAlias localhost
+  ServerAdmin root@localhost
+  DocumentRoot /var/www/html
+  RewriteEngine              On
+  RewriteRule     ^/$    https://%{HTTP_HOST}/console [R,L]
+  RewriteRule     ^(.*)$     https://%{HTTP_HOST}$1 [R,L]
+</VirtualHost>
+
+<VirtualHost *:443>
+  # ServerName we will inherit from other config;
+  # ServerAlias is to make sure "localhost" traffic goes here regardless.
+  ServerAlias localhost
+  ServerAdmin root@localhost
+  DocumentRoot /var/www/html
+  RewriteEngine              On
+  RewriteRule     ^/$    https://%{HTTP_HOST}/console [R,L]
+  SSLEngine on
+  SSLProxyEngine on
+  SSLCertificateFile /etc/pki/tls/certs/localhost.crt
+  SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
+  RequestHeader set X_FORWARDED_PROTO 'https'
+  RequestHeader set Front-End-Https "On"
+  ProxyTimeout 300
+  ProxyPass /console http://<%= scope.lookupvar('::openshift_origin::console_listen_ip') %>:8118/console
+  ProxyPassReverse /console http://<%= scope.lookupvar('::openshift_origin::console_listen_ip') %>:8118/console
+
+  ProxyPass /broker http://<%= scope.lookupvar('::openshift_origin::broker_listen_ip') %>:8080/broker
+  ProxyPassReverse / http://<%= scope.lookupvar('::openshift_origin::broker_listen_ip') %>:8080/
+</VirtualHost>
+
+ProxyPreserveHost On
+TraceEnable off


### PR DESCRIPTION
Previously, the Broker API and Web Console could only bind to the
loopback address (127.0.0.1).  This makes remotely connecting
to these services difficult by requiring workaround solutions such
as SSH tunneling.

Since iptables must open additional ports, the following commit
should also be accepted for full functionality:

8515ea8c6017c87731fb7dcae86aa8b18b2ba51f

The change introduces the $broker_listen_ip and $console_listen_ip
paramaters that are used to specify the IP address the broker and
web console will bind to.  Defaults to '127.0.0.1' for backwards
compatibility.  Note: $broker_ip_addr was not used since it
defaults to $::ipaddress which breaks backwards compatability.
