### PR TITLE
Fixes Startup of Node Services

### DIFF
--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -167,7 +167,7 @@ class openshift_origin::node {
     ],
     provider => $::openshift_origin::params::os_init_provider,
   }
-  
+
   file { 'create node setting markers dir':
     ensure  => 'directory',
     path    => '/var/lib/openshift/.settings',
@@ -183,6 +183,7 @@ class openshift_origin::node {
     owner   => 'root',
     group   => 'root',
     mode    => '0755',
+    require => Package['rubygem-openshift-origin-node'],
   }
 
   file { '/etc/openshift/env/OPENSHIFT_UMASK':

--- a/manifests/plugins/frontend/nodejs_websocket.pp
+++ b/manifests/plugins/frontend/nodejs_websocket.pp
@@ -25,11 +25,14 @@ class openshift_origin::plugins::frontend::nodejs_websocket {
   )
   
   service { 'openshift-node-web-proxy':
-    enable  => true,
-    require => [
+    enable     => true,
+    ensure     => true,
+    hasstatus  => true,
+    hasrestart => true,
+    require    => [
       Package['openshift-origin-node-proxy'],      
       Package['openshift-origin-node-util'],
     ],
-    provider => $openshift_origin::params::os_init_provider,
+    provider   => $openshift_origin::params::os_init_provider,
   }
 }


### PR DESCRIPTION
Previously, several node services such as oddjobd and
opeshift-node-web-proxy would be in a "down" state after the
successful completion of a puppet agent run. Additionally, the
port-proxy package and service was not being configured.

This patch creates the proper dependencies between configuration
files and services to ensure proper service management.
