### PR TITLE
Add COMMUNITY_URL to console config

### DIFF
--- a/templates/console/console.conf.erb
+++ b/templates/console/console.conf.erb
@@ -10,6 +10,13 @@ BROKER_URL=https://<%= scope.lookupvar('::openshift_origin::broker_hostname') %>
 DOMAIN_SUFFIX="<%= scope.lookupvar('::openshift_origin::domain') %>"
 
 #
+# A URL used when creating links to the OpenShift community sites
+#
+# Optional
+#
+COMMUNITY_URL=https://www.openshift.com/
+
+#
 # A proxy URL to use when connecting with the broker.
 #
 # Optional


### PR DESCRIPTION
The generated console.conf was missing the COMMUNITY_URL variable, which
was causing documentation links to be broken in the console.
