### PR TITLE
Adds Support for Configuring NTP Servers

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -254,6 +254,15 @@ only alphanumeric values in this script as others may cause syntax
 errors depending on context. If non-alphanumeric values are required,
 update them separately after installation.
 
+==== ntp_servers
+If configure_ntp is set to true (default), ntp_servers allows users to
+specify an array of NTP servers used for clock synchronization.
+
+Default: ['time.apple.com iburst', 'pool.ntp.org iburst', 'clock.redhat.com iburst']
+
+NOTE: Use iburst after every ntp server definition to speed up the
+initial synchronization.
+
 ==== activemq_admin_password
 This is the admin password for the ActiveMQ admin console, which is
 not needed by OpenShift but might be useful in troubleshooting.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,6 +162,12 @@
 #   of 60 seconds and may be dropped if the clocks are too far out of 
 #   synch.  However, NTP is not necessary if the clock will be kept in 
 #   synch by some other means.
+#
+# [*ntp_servers*]
+#   Default: ['time.apple.com iburst', 'pool.ntp.org iburst', 'clock.redhat.com iburst']
+#   Specifies one or more servers for NTP clock syncronization.
+#   Note: Use iburst after every ntp server definition to speed up
+#         the initial synchronization.
 # 
 # Passwords used to secure various services. You are advised to specify
 # only alphanumeric values in this script as others may cause syntax
@@ -488,6 +494,7 @@ class openshift_origin (
   $broker_ip_addr                       = $ipaddress,
   $node_ip_addr                         = $ipaddress,
   $configure_ntp                        = true,  
+  $ntp_servers                          = ['time.apple.com iburst', 'pool.ntp.org iburst', 'clock.redhat.com iburst'],
   $activemq_admin_password              = inline_template('<%= require "securerandom"; SecureRandom.base64 %>'),
   $mcollective_user                     = 'mcollective',
   $mcollective_password                 = 'marionette',

--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -44,7 +44,7 @@ class openshift_origin::role {
     )
 
     ensure_resource('class', 'ntp', {
-        servers    => ['time.apple.com iburst', 'pool.ntp.org iburst', 'clock.redhat.com iburst'],
+        servers    => $::openshift_origin::ntp_servers,
         autoupdate => true,
       }
     )


### PR DESCRIPTION
Previously, the ntp servers used by an OpenShift deployment were
hard coded to:

['time.apple.com iburst', 'pool.ntp.org iburst', 'clock.redhat.com iburst']

This causes problems for deployments that do not allow ntp clock
synchronization with outside entities.  This patch adds the
$ntp_servers parameter for configuring an array of NTP servers and
uses the above mentioned array of servers to maintain backwards
compatibility.
