### PR TITLE
Add Support for Example Top Level Manifests

### DIFF
--- a/configure_origin.pp.broker_example
+++ b/configure_origin.pp.broker_example
@@ -1,0 +1,33 @@
+class { 'openshift_origin' :
+  # Components to install on this host:
+  roles			 => ['broker','named','activemq','datastore'],
+
+  # BIND / named config
+  # This is the key for updating the OpenShift BIND server
+  bind_key                   => '<DNSSEC_BIND_KEY>',
+  # The domain under which applications should be created.
+  domain                     => 'example.com',
+  # Apps would be named <app>-<namespace>.example.com
+  # This also creates hostnames for local components under our domain
+  register_host_with_named   => true,
+  # Forward requests for other domains (to Google by default)
+  conf_named_upstream_dns    => ['<UPSTREAM_DNS_IP>'],
+
+  # NTP Servers for OpenShift hosts to sync time
+  ntp_servers                => ['<NTP_SERVER_FQDN> iburst'],
+
+  # The FQDNs of the OpenShift component hosts
+  broker_hostname            => '<BROKER_HOSTNAME>.example.com',
+  named_hostname             => '<BROKER_HOSTNAME>.example.com',
+  datastore_hostname         => '<BROKER_HOSTNAME>.example.com',
+  activemq_hostname          => '<BROKER_HOSTNAME>.example.com',
+
+  # Auth OpenShift users created with htpasswd tool in /etc/openshift/htpasswd
+  broker_auth_plugin         => 'htpasswd',
+  # Username and password for initial openshift user
+  openshift_user1            => 'openshift',
+  openshift_password1        => 'password',
+
+  #Enable development mode for more verbose logs
+  development_mode           => true,
+}

--- a/configure_origin.pp.node_example
+++ b/configure_origin.pp.node_example
@@ -1,0 +1,39 @@
+class { 'openshift_origin' :
+  # Components to install on this host:
+  roles			 => ['node'],
+
+  # BIND / named config
+  # This is the key for updating the OpenShift BIND server
+  bind_key                   => '<DNSSEC_BIND_KEY>',
+  # This is the IP address for OpenShift BIND server - here, the broker.
+  named_ip_addr              => '<BROKER_IP_ADDRESS>',
+  # The domain under which applications should be created.
+  domain                     => 'example.com',
+  # Apps would be named <app>-<namespace>.example.com
+  # This also creates hostnames for local components under our domain
+  register_host_with_named   => true,
+
+  # The FQDNs of the OpenShift component hosts we will need
+  broker_hostname            => '<BROKER_HOSTNAME>.example.com',
+  activemq_hostname          => '<BROKER_HOSTNAME>.example.com',
+  node_hostname              => '<NODE_HOSTNAME>.example.com',
+
+  # NTP Servers for OpenShift hosts to sync time
+  ntp_servers                => ['<NTP_SERVER_FQDN> iburst'],
+
+  # To enable installing the Jenkins cartridge:
+  install_method             => 'yum',
+  jenkins_repo_base          => 'http://pkg.jenkins-ci.org/redhat',
+
+  # Cartridges to install on Node hosts
+  install_cartridges         => ['php', 'mysql'],
+ 
+  #Enable development mode for more verbose logs
+  #development_mode           => true,
+
+  # Set if using an external-facing ethernet device other than eth0
+  #conf_node_external_eth_dev => 'eth0',
+
+  #If using with GDM, or have users with UID 500 or greater, put in this list
+  #node_unmanaged_users       => ['user1'],
+}


### PR DESCRIPTION
Previously, a user would need to manually create the top-level
manifest (configure_origin.pp).  This patch creates 2 sample
top-level manifests in the root DIR of the project and will help
reduce user error during deployments.  Users can simply copy,
rename the sample files and edit a few parameters to
successfully deploy a broker or node host.
