### PR TITLE
Bug 1057726 - Remove jetty.xml from ActiveMQ configuration

### DIFF
--- a/templates/activemq/activemq.xml.erb
+++ b/templates/activemq/activemq.xml.erb
@@ -164,11 +164,13 @@
     </broker>
 
     <!--
-        Enable web consoles, REST and Ajax APIs and demos
+        Enable web consoles, REST and Ajax APIs and demos.  Unneeded for
+        OpenShift.
 
         Take a look at ${ACTIVEMQ_HOME}/conf/jetty.xml for more details
+
+        <import resource="jetty.xml"/>
     -->
-    <import resource="jetty.xml"/>
 
 </beans>
 <!-- END SNIPPET: example -->


### PR DESCRIPTION
I'm chosing to leave the jetty.xml on disk in case admins would like to quickly
enable it for debugging purposes.
