### PR TITLE
Use node_ip_addr for PUBLIC_IP instead of local interface IP

### DIFF
--- a/templates/node/node.conf.erb
+++ b/templates/node/node.conf.erb
@@ -1,7 +1,7 @@
 # These should not be left at default values, even for a demo.
 # "PUBLIC" networking values are ones that end-users should be able to reach.
 PUBLIC_HOSTNAME="<%= scope.lookupvar('::openshift_origin::node_hostname') %>"                         # The node host's public hostname
-PUBLIC_IP="<%= @ipaddress %>"                              # The node host's public IP address
+PUBLIC_IP="<%= scope.lookupvar('::openshift_origin::node_ip_addr') %>"                                # The node host's public IP address
 BROKER_HOST="<%= scope.lookupvar('::openshift_origin::broker_hostname') %>"                     # IP or DNS name of broker server for REST API
 
 # Usually (unless in a demo) this should be changed to the domain for your installation:


### PR DESCRIPTION
I believe node.conf PUBLIC_IP configuration option must have the value that is set via node_ip_addr (instead of local interface IP).
