### PR TITLE
Fixes DHCP Client Settings

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -79,7 +79,7 @@ class openshift_origin::broker {
       require => Package['openshift-origin-broker'],
     }
   }
-  
+
   file { 'quickstarts':
     ensure  => present,
     path    => '/etc/openshift/quickstarts.json',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -549,24 +549,24 @@ class openshift_origin (
   $install_cartridges                   = ['10gen-mms-agent','cron','diy','haproxy','mongodb',
                                            'nodejs','perl','php','phpmyadmin','postgresql',
                                            'python','ruby','jenkins','jenkins-client','mariadb'],
-  $update_resolv_conf                   = true,
+  $update_conf_files                    = true,
 ){
   include openshift_origin::role
   if member( $roles, 'named' ) {
     class{ 'openshift_origin::role::named': 
-      before => Class['openshift_origin::update_resolv_conf'],
+      before => Class['openshift_origin::update_conf_files'],
     } 
     if member( $roles, 'broker' )    { Class['openshift_origin::role::named']    -> Class['openshift_origin::role::broker'] }
     if member( $roles, 'node' )      { Class['openshift_origin::role::named']    -> Class['openshift_origin::role::node'] }
     if member( $roles, 'activemq' )  { Class['openshift_origin::role::named']    -> Class['openshift_origin::role::activemq'] }
     if member( $roles, 'datastore' ) { Class['openshift_origin::role::named']    -> Class['openshift_origin::role::datastore'] }
   }
-  if member( $roles, 'broker' ) {    class{ 'openshift_origin::role::broker': require => Class['openshift_origin::update_resolv_conf'] } }
-  if member( $roles, 'node' ) {      class{ 'openshift_origin::role::node': require => Class['openshift_origin::update_resolv_conf'] } }
-  if member( $roles, 'activemq' ) {  class{ 'openshift_origin::role::activemq': require => Class['openshift_origin::update_resolv_conf'] } }
-  if member( $roles, 'datastore' ) { class{ 'openshift_origin::role::datastore': require => Class['openshift_origin::update_resolv_conf'] } }
+  if member( $roles, 'broker' ) {    class{ 'openshift_origin::role::broker': require => Class['openshift_origin::update_conf_files'] } }
+  if member( $roles, 'node' ) {      class{ 'openshift_origin::role::node': require => Class['openshift_origin::update_conf_files'] } }
+  if member( $roles, 'activemq' ) {  class{ 'openshift_origin::role::activemq': require => Class['openshift_origin::update_conf_files'] } }
+  if member( $roles, 'datastore' ) { class{ 'openshift_origin::role::datastore': require => Class['openshift_origin::update_conf_files'] } }
   
-  class{ 'openshift_origin::update_resolv_conf': }
+  class{ 'openshift_origin::update_conf_files': }
 
   if $::operatingsystem == 'Fedora' {
     package { 'NetworkManager':

--- a/manifests/mcollective_server.pp
+++ b/manifests/mcollective_server.pp
@@ -24,7 +24,7 @@ class openshift_origin::mcollective_server {
 
   # Ensure classes are run in order
   Class['Openshift_origin::Role']               -> Class['Openshift_origin::Mcollective_server']
-  Class['Openshift_origin::Update_resolv_conf'] -> Class['Openshift_origin::Mcollective_server']
+  Class['Openshift_origin::Update_conf_files'] -> Class['Openshift_origin::Mcollective_server']
 
   file { 'mcollective server config':
     ensure  => present,

--- a/manifests/mongo.pp
+++ b/manifests/mongo.pp
@@ -72,7 +72,7 @@ class openshift_origin::mongo {
 
     exec { '/usr/sbin/oo-mongo-setup':
       command => $cmd,
-      require => [File['mongo setup script'],Class['openshift_origin::update_resolv_conf']]
+      require => [File['mongo setup script'],Class['openshift_origin::update_conf_files']]
     }
   }
 

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -37,7 +37,7 @@ class openshift_origin::node {
   
   include openshift_origin::cartridges
   include openshift_origin::mcollective_server  
-  
+
   file { 'openshift node config':
     ensure  => present,
     path    => '/etc/openshift/node.conf',

--- a/manifests/update_conf_files.pp
+++ b/manifests/update_conf_files.pp
@@ -1,4 +1,4 @@
-class openshift_origin::update_resolv_conf {
+class openshift_origin::update_conf_files {
   augeas { 'network-scripts':
     context => "/files/etc/sysconfig/network-scripts/ifcfg-${::openshift_origin::conf_node_external_eth_dev}",
     changes => [
@@ -6,7 +6,16 @@ class openshift_origin::update_resolv_conf {
       "set DNS1 ${::openshift_origin::named_ip_addr}",
     ],
   }
-  
+
+  file { 'dhcpclient':
+    ensure  => present,
+    path    => "/etc/dhcp/dhclient-${::openshift_origin::conf_node_external_eth_dev}.conf",
+    content => template('openshift_origin/dhclient_conf.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+  }
+
   file { '/etc/resolv.conf':
     content => "search ${::openshift_origin::domain}\nnameserver ${::openshift_origin::named_ip_addr}"
   }

--- a/templates/dhclient_conf.erb
+++ b/templates/dhclient_conf.erb
@@ -1,0 +1,3 @@
+prepend domain-name-servers <%= scope.lookupvar('::openshift_origin::named_ip_addr') %>;
+supersede host-name "<%= @hostname %>";
+supersede domain-name "<%= scope.lookupvar('::openshift_origin::domain') %>";


### PR DESCRIPTION
Previously, broker and node servers would revert to hostname
settings after reboot due to upstream DHCP Server behavior.

The DNS server information in /etc/resolv.conf would default back
the server returned from your DHCP server on the next boot of the
server.

This patch configures a /etc/dhcp/dhclient-{$network device}.conf
file to supersede the default behavior.
