### PR TITLE
Use internal firewall naming scheme

### DIFF
--- a/manifests/activemq.pp
+++ b/manifests/activemq.pp
@@ -89,7 +89,7 @@ class openshift_origin::activemq {
     }
   )
 
-  openshift::firewall{ 'activemq':
+  openshift_origin::firewall{ 'activemq':
     port      => '61613',
     protocol  => 'tcp',
   }

--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -173,12 +173,12 @@ class openshift_origin::broker {
     include openshift_origin::login_shell
   }
   
-  ensure_resource( 'openshift::firewall', 'http', {
+  ensure_resource( 'openshift_origin::firewall', 'http', {
       service => 'http',
     }
   )
   
-  ensure_resource( 'openshift::firewall', 'https', {
+  ensure_resource( 'openshift_origin::firewall', 'https', {
       service => 'https',
     }
   )

--- a/manifests/console.pp
+++ b/manifests/console.pp
@@ -95,12 +95,12 @@ class openshift_origin::console {
     hasrestart => true,
   }
   
-  ensure_resource( 'openshift::firewall', 'http', {
+  ensure_resource( 'openshift_origin::firewall', 'http', {
       service => 'http',
     }
   )
   
-  ensure_resource( 'openshift::firewall', 'https', {
+  ensure_resource( 'openshift_origin::firewall', 'https', {
       service => 'https',
     }
   )

--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -13,7 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-define openshift::firewall( $service=undef, $port=undef, $protocol=undef ) {
+define openshift_origin::firewall( $service=undef, $port=undef, $protocol=undef ) {
   ensure_resource('package', 'iptables', {})
   ensure_resource('package', 'firewalld', {
       ensure => 'absent',

--- a/manifests/mongo.pp
+++ b/manifests/mongo.pp
@@ -81,7 +81,7 @@ class openshift_origin::mongo {
     enable    => true,
   }
   
-  openshift::firewall{ 'mongo-firewall':
+  openshift_origin::firewall{ 'mongo-firewall':
     port      => '27017',
     protocol  => 'tcp',
   }

--- a/manifests/named.pp
+++ b/manifests/named.pp
@@ -131,12 +131,12 @@ class openshift_origin::named {
   
   }
   
-  openshift::firewall{ 'dns-tcp':
+  openshift_origin::firewall{ 'dns-tcp':
     port     => 53,
     protocol => 'tcp',
   }
 
-  openshift::firewall{ 'dns-udp':
+  openshift_origin::firewall{ 'dns-udp':
     port     => 53,
     protocol => 'udp',
   }

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -215,22 +215,22 @@ class openshift_origin::node {
     mode    => '0644',
   }
   
-  ensure_resource( 'openshift::firewall', 'http', {
+  ensure_resource( 'openshift_origin::firewall', 'http', {
       service => 'http',
     }
   )
   
-  ensure_resource( 'openshift::firewall', 'https', {
+  ensure_resource( 'openshift_origin::firewall', 'https', {
       service => 'https',
     }
   )
   
-  openshift::firewall{ 'node-http':
+  openshift_origin::firewall{ 'node-http':
     port      => '8000',
     protocol  => 'tcp',
   }
 
-  openshift::firewall{ 'node-https':
+  openshift_origin::firewall{ 'node-https':
     port      => '8443',
     protocol  => 'tcp',
   }

--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -50,7 +50,7 @@ class openshift_origin::role {
     )
   }
   
-  ensure_resource( 'openshift::firewall', 'ssh', {
+  ensure_resource( 'openshift_origin::firewall', 'ssh', {
       service => 'ssh',
     }
   )


### PR DESCRIPTION
Using the simple 'firewall' naming breaks with most puppet installations. This modifies it so that the firewall resource name works as expected.
