### PR TITLE
Add appropriate permissions to apply to the mcollective log file

### DIFF
--- a/manifests/mcollective_client.pp
+++ b/manifests/mcollective_client.pp
@@ -31,4 +31,13 @@ class openshift_origin::mcollective_client {
     mode    => '0644',
     require => Package['mcollective-client'],
   }
+
+  file { 'mcollective log file':
+    ensure  => present,
+    path    => "/var/log/openshift/broker/${::openshift_origin::params::ruby_scl_prefix}mcollective-client.log",
+    owner   => 'apache',
+    group   => 'root',
+    mode    => '0644',
+    require => Package['mcollective-client'],
+  }
 }


### PR DESCRIPTION
When spinning up a brand new instance of openshift all-in-one type of deployment, oo-diagnostics complains about a particular log file,  here's a snippet of the output:

```
WARN: test_broker_httpd_error_log
      broker error_log: this problem indicates mcollective client logging is failing:
        Could not start logger: Errno::EACCES Permission denied - /var/log/openshift/broker/mcollective-client.log

      Please fix this issue with the following commands:
        # chown apache:root /var/log/-mcollective-client.log
        # service openshift-broker restart
```

I've adjusted mcollective_client.pp appropriately.
