### PR TITLE
Adds MongoDB Replica Set Support

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -204,6 +204,12 @@ DNS entries for the hostnames of the other components being
 installed on this host as well. If you are using a nameserver set
 up separately, you are responsible for all necessary DNS entries.
 
+=== datastore1_ip|datastore2_ip_addr|datastore3_ip_addr
+Default: undef
+
+IP addresses of the first 3 MongoDB servers in a replica set.
+Add datastoreX_ip_addr parameters for larger clusters.
+
 ==== named_ip_addr
 Default: IP of a named instance or current IP if installing on this 
 node. This is used by every node to configure its primary name server.
@@ -302,6 +308,49 @@ This is the name of the database in MongoDB in which the broker will
 store data.
 
 Default: openshift_broker
+
+==== mongodb_port
+Default: '27017'
+
+The TCP port used for MongoDB to listen on.
+
+==== mongodb_replicasets
+Default: false
+
+Enable/disable MongoDB replica sets for database high-availability.
+
+==== mongodb_replica_name
+Default: 'openshift'
+
+The MongoDB replica set name when $mongodb_replicasets is true.
+
+==== mongodb_replica_primary
+Default: undef
+
+Set the host as the primary with true or secondary with false.
+
+==== mongodb_replica_primary_ip_addr
+Default: undef
+
+The IP address of the Primary host within the MongoDB replica set.
+
+==== mongodb_replicasets_members
+Default: undef
+
+An array of [host:port] of replica set hosts.
+Example: ['10.10.10.10:27017', '10.10.10.11:27017', '10.10.10.12:27017']
+
+==== mongodb_keyfile
+Default: '/etc/mongodb.keyfile'
+
+The file containing the $mongodb_key used to authenticate MongoDB
+replica set members.
+
+==== mongodb_key
+Default: 'changeme'
+
+The key used by members of a MongoDB replica set to authenticate
+one another.
 
 ==== openshift_user1
 ==== openshift_password1

--- a/configure_origin.pp.mongo_replset.example
+++ b/configure_origin.pp.mongo_replset.example
@@ -1,0 +1,53 @@
+  $my_hostname='<BROKER01_FQDN>'
+
+  exec { "set_hostname":
+    command => "/bin/hostname ${my_hostname}",
+    unless  => "/bin/hostname | /bin/grep ${my_hostname}",
+  }
+
+  exec { "set_etc_hostname":
+    command => "/bin/echo ${my_hostname} > /etc/hostname",
+    unless  => "/bin/grep ${my_hostname} /etc/hostname",
+  }
+
+class { 'openshift_origin' :
+  # Mongo Replication
+  mongodb_replicasets             => true,
+  mongodb_replica_primary         => true, # Set to false for secondary mongo servers
+  mongodb_replica_primary_ip_addr => '<PRIMARY_IP>', # i.e. broker01 IP address
+  # <IP>:<Port> of MongoDB replication members.
+  mongodb_replicasets_members     => ['<MEMBER1_IP>:<MONGO_PORT>', '<MEMBER2_IP>:<MONGO_PORT>', '<MEMBER3_IP>:<MONGO_PORT>'],
+  mongodb_key                     => '<MONGODB_REPL_KEY>',
+  datastore1_ip_addr              => '<MEMBER1_IP>',
+  datastore2_ip_addr              => '<MEMBER2_IP>',
+  datastore3_ip_addr              => '<MEMBER3_IP>',
+  
+  # Components to install on this host:
+  roles                      => ['broker','named','activemq','datastore'],
+  # BIND / named config
+  # This is the key for updating the OpenShift BIND server
+  bind_key                   => '<DNSSEC_BIND_KEY>',
+  # The domain under which applications should be created.
+  domain                     => '<FQDN>',
+  # Apps would be named <app>-<namespace>.example.com
+  # This also creates hostnames for local components under our domain
+  register_host_with_named   => true,
+  # Forward requests for other domains (to Google by default)
+  conf_named_upstream_dns    => ['<UPSTREAM_DNS_IP>'],
+  # NTP Servers for OpenShift hosts to sync time
+  ntp_servers                => ["<UPSTREAM_NTP_FQDN> iburst"],
+  # The FQDNs of the OpenShift component hosts
+  broker_hostname            => $my_hostname,
+  named_hostname             => $my_hostname,
+  datastore_hostname         => $my_hostname,
+  activemq_hostname          => $my_hostname,
+  # Auth OpenShift users created with htpasswd tool in /etc/openshift/htpasswd
+  broker_auth_plugin         => 'htpasswd',
+  # Username and password for initial openshift user
+  openshift_user1            => 'openshift',
+  openshift_password1        => 'password',
+  #Enable development mode for more verbose logs
+  development_mode           => true,
+  # Set if using an external-facing ethernet device other than eth0
+  conf_node_external_eth_dev => 'eth0',
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,6 +106,11 @@
 #   DNS entries for the hostnames of the other components being 
 #   installed on this host as well. If you are using a nameserver set
 #   up separately, you are responsible for all necessary DNS entries.
+#
+# [*datastore1_ip|datastore2_ip_addr|datastore3_ip_addr*]
+#   Default: undef
+#   IP addresses of the first 3 MongoDB servers in a replica set.
+#   Add datastoreX_ip_addr parameters for larger clusters.
 # 
 # [*named_ip_addr*]
 #   Default: IP of a named instance or current IP if installing on this 
@@ -209,6 +214,41 @@
 #   This is the name of the database in MongoDB in which the broker will
 #   store data.
 # 
+# [*mongodb_port*]
+#   Default: '27017'
+#   The TCP port used for MongoDB to listen on.
+#
+# [*mongodb_replicasets*]
+#   Default: false
+#   Enable/disable MongoDB replica sets for database high-availability.
+#
+# [*mongodb_replica_name*]
+#   Default: 'openshift'
+#   The MongoDB replica set name when $mongodb_replicasets is true.
+#
+# [*mongodb_replica_primary*]
+#   Default: undef
+#   Set the host as the primary with true or secondary with false.
+#
+# [*mongodb_replica_primary_ip_addr*]
+#   Default: undef
+#   The IP address of the Primary host within the MongoDB replica set.
+#
+# [*mongodb_replicasets_members*]
+#   Default: undef
+#   An array of [host:port] of replica set hosts. Example:
+#   ['10.10.10.10:27017', '10.10.10.11:27017', '10.10.10.12:27017']
+#
+# [*mongodb_keyfile*]
+#   Default: '/etc/mongodb.keyfile'
+#   The file containing the $mongodb_key used to authenticate MongoDB
+#   replica set members.
+#
+# [*mongodb_key*]
+#   Default: 'changeme'
+#   The key used by members of a MongoDB replica set to authenticate
+#   one another.
+#
 # [*openshift_user1*]
 # [*openshift_password1*]
 #   Default: demo/changeme
@@ -494,6 +534,9 @@ class openshift_origin (
   $named_hostname                       = "ns1.${domain}",
   $activemq_hostname                    = "activemq.${domain}",
   $datastore_hostname                   = "mongodb.${domain}",
+  $datastore1_ip_addr                   = undef,
+  $datastore2_ip_addr                   = undef,
+  $datastore3_ip_addr                   = undef,
   $named_ip_addr                        = $ipaddress,
   $bind_key                             = '',
   $bind_krb_keytab                      = '',
@@ -513,6 +556,14 @@ class openshift_origin (
   $mongodb_broker_user                  = 'openshift',
   $mongodb_broker_password              = 'mongopass',
   $mongodb_name                         = 'openshift_broker',
+  $mongodb_port                         = '27017',
+  $mongodb_replicasets                  = false,
+  $mongodb_replica_name                 = 'openshift',
+  $mongodb_replica_primary              = undef,
+  $mongodb_replica_primary_ip_addr      = undef,
+  $mongodb_replicasets_members          = undef,
+  $mongodb_keyfile                      = '/etc/mongodb.keyfile',
+  $mongodb_key                          = 'changeme',
   $openshift_user1                      = 'demo',
   $openshift_password1                  = 'changeme',
   $conf_broker_auth_salt                = inline_template('<%= require "securerandom"; SecureRandom.base64 %>'),

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -122,4 +122,18 @@ class openshift_origin::params {
     undef   => $node_shmall_default,
     default => $::openshift_origin::node_shmall,
   }
+
+  case $::operatingsystem {
+    'RedHat', 'CentOS': {
+      $user  = pick($user, 'mongod')
+      $group = pick($group, 'mongod')
+    }
+    'Fedora': {
+      $user  = pick($user, 'mongodb')
+      $group = pick($group, 'mongodb')
+    }
+    default: {
+      fail("${::operatingsystem} is not supported")
+    }
+  }
 }

--- a/templates/broker/broker.conf.erb
+++ b/templates/broker/broker.conf.erb
@@ -12,9 +12,14 @@ DEFAULT_GEAR_CAPABILITIES="<%= scope.lookupvar('::openshift_origin::conf_default
 DEFAULT_GEAR_SIZE="<%= scope.lookupvar('::openshift_origin::conf_default_gear_size') %>"
 
 #Broker datastore configuration
-MONGO_REPLICA_SETS=false
+MONGO_REPLICA_SETS=<%= scope.lookupvar('::openshift_origin::mongodb_replicasets') %>
+<% if scope.lookupvar('::openshift_origin::mongodb_replicasets') == true %>
+# Replica set example: "<host-1>:<port-1> <host-2>:<port-2> ..."
+MONGO_HOST_PORT="<%= scope.lookupvar('::openshift_origin::mongodb_replicasets_members').join(',') %>"
+<% else %>
 # Replica set example: "<host-1>:<port-1> <host-2>:<port-2> ..."
 MONGO_HOST_PORT="<%= scope.lookupvar('::openshift_origin::datastore_hostname') %>:27017"
+<% end %>
 MONGO_USER="<%= scope.lookupvar('::openshift_origin::mongodb_broker_user') %>"
 MONGO_PASSWORD="<%= scope.lookupvar('::openshift_origin::mongodb_broker_password') %>"
 MONGO_DB="<%= scope.lookupvar('::openshift_origin::mongodb_name') %>"

--- a/templates/broker/plugins/auth/mongo/mongo.conf.plugin.erb
+++ b/templates/broker/plugins/auth/mongo/mongo.conf.plugin.erb
@@ -1,6 +1,11 @@
-MONGO_REPLICA_SETS=false
+MONGO_REPLICA_SETS=<%= scope.lookupvar('::openshift_origin::mongodb_replicasets') %>
+<% if scope.lookupvar('::openshift_origin::mongodb_replicasets') == true %>
+# Replica set example: "<host-1>:<port-1> <host-2>:<port-2> ..."
+MONGO_HOST_PORT="<%= scope.lookupvar('::openshift_origin::mongodb_replicasets_members').join(',') %>"
+<% else %>
 # Replica set example: "<host-1>:<port-1> <host-2>:<port-2> ..."
 MONGO_HOST_PORT="<%= scope.lookupvar('::openshift_origin::datastore_hostname') %>:27017"
+<% end %>
 MONGO_USER="<%= scope.lookupvar('::openshift_origin::mongodb_broker_user') %>"
 MONGO_PASSWORD="<%= scope.lookupvar('::openshift_origin::mongodb_broker_password') %>"
 MONGO_DB="<%= scope.lookupvar('::openshift_origin::mongodb_name') %>"


### PR DESCRIPTION
Previously, the openshift puppet module only supported a single
datastore host.  This patch adds support for MongoDB replica sets.

The patch supports deploying replica set members with a single
puppet run.
