### PR TITLE
Fixes activemq_admin_password

### DIFF
--- a/templates/activemq/jetty-realm.properties.erb
+++ b/templates/activemq/jetty-realm.properties.erb
@@ -17,4 +17,4 @@
 
 # Defines users that can access the web (console, demo, etc.)
 # username: password [,rolename ...]
-admin: <%= scope.lookupvar('::openshift_origin::mq_server_password') %>, admin 
+admin: <%= scope.lookupvar('::openshift_origin::msgserver_admin_password') %>, admin 


### PR DESCRIPTION
Previously, the jetty-realm.properties template referenced a
non-existent parameter that caused the associated file
to contain an empty password for the admin account.
