### PR TITLE
Adds Support for Clustering ActiveMQ & Mcollective Client

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -263,6 +263,31 @@ Default: ['time.apple.com iburst', 'pool.ntp.org iburst', 'clock.redhat.com ibur
 NOTE: Use iburst after every ntp server definition to speed up the
 initial synchronization.
 
+==== activemq_cluster
+Default: false
+
+Set to true to cluster ActiveMQ for high-availability and scalability
+of OpenShift message queues.
+
+==== activemq_cluster_members
+Default: undef
+
+An array of ActiveMQ server hostnames to be included in the ActiveMQ
+cluster. Required when parameter activemq_cluster is set to true.
+
+==== mcollective_cluster_members
+Default: $activemq_cluster_members
+
+An array of ActiveMQ server hostnames to be included in the ActiveMQ
+cluster. Required when parameter activemq_cluster is set to true.
+
+==== activemq_password
+Default 'changeme'
+
+Password used by ActiveMQ's amquser.  The amquser is used to authenticate
+ActiveMQ inter-cluster communication.  Only used when activemq_cluster
+is true.
+
 ==== activemq_admin_password
 This is the admin password for the ActiveMQ admin console, which is
 not needed by OpenShift but might be useful in troubleshooting.

--- a/manifests/mcollective_client.pp
+++ b/manifests/mcollective_client.pp
@@ -22,6 +22,14 @@ class openshift_origin::mcollective_client {
     } 
   )
 
+  $cluster_members = $::openshift_origin::mcollective_cluster_members
+
+  if $cluster_members {
+    $pool_size = size($cluster_members)
+  } else {
+    $pool_size = '1'
+  }
+
   file { 'mcollective client config':
     ensure  => present,
     path    => "${::openshift_origin::params::ruby_scl_path_prefix}/etc/mcollective/client.cfg",

--- a/manifests/mcollective_server.pp
+++ b/manifests/mcollective_server.pp
@@ -22,6 +22,14 @@ class openshift_origin::mcollective_server {
     } 
   )
 
+  $cluster_members = $::openshift_origin::mcollective_cluster_members
+
+  if $cluster_members {
+    $pool_size = size($cluster_members)
+  } else {
+    $pool_size = '1'
+  }
+
   # Ensure classes are run in order
   Class['Openshift_origin::Role']               -> Class['Openshift_origin::Mcollective_server']
   Class['Openshift_origin::Update_conf_files'] -> Class['Openshift_origin::Mcollective_server']

--- a/templates/activemq/activemq-network.xml.erb
+++ b/templates/activemq/activemq-network.xml.erb
@@ -1,0 +1,158 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:amq="http://activemq.apache.org/schema/core"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+  http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+    <!-- Allows us to use system properties as variables in this configuration file -->
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="locations">
+            <value>file:${activemq.conf}/credentials.properties</value>
+        </property>
+    </bean>
+
+    <!--
+        The <broker> element is used to configure the ActiveMQ broker.
+    -->
+    <broker xmlns="http://activemq.apache.org/schema/core"
+	    brokerName="<%= scope.lookupvar('::openshift_origin::activemq_hostname') %>"
+	    useJmx="true"
+	    dataDirectory="${activemq.data}"
+            schedulePeriodForDestinationPurge="60000">
+        <!--
+            For better performances use VM cursor and small memory limit.
+            For more information, see:
+            http://activemq.apache.org/message-cursors.html
+        -->
+
+        <destinationPolicy>
+		<policyMap>
+			<policyEntries>
+				<policyEntry topic=">" producerFlowControl="false"/>
+				<policyEntry queue="*.reply.>" gcInactiveDestinations="true"
+					inactiveTimoutBeforeGC="300000" />
+			</policyEntries>
+		</policyMap>
+        </destinationPolicy>
+
+
+        <!--
+            The managementContext is used to configure how ActiveMQ is exposed in
+            JMX. By default, ActiveMQ uses the MBean server that is started by
+            the JVM. For more information, see:
+
+            http://activemq.apache.org/jmx.html
+        -->
+        <managementContext>
+            <managementContext createConnector="false"/>
+        </managementContext>
+
+	<networkConnectors>
+<% @cluster_remote_members.each do |cluster_remote_member| -%>
+		<networkConnector name="<%= scope.lookupvar('::openshift_origin::activemq_hostname') %>-<%= cluster_remote_member %>-topic" uri="static:(tcp://<%= cluster_remote_member %>:61616)" userName="amquser" password="<%= scope.lookupvar('::openshift_origin::activemq_password') %>">
+			<excludedDestinations><queue physicalName=">" /></excludedDestinations>
+		</networkConnector>
+		<networkConnector name="<%= scope.lookupvar('::openshift_origin::activemq_hostname') %>-<%= cluster_remote_member %>-queue" uri="static:(tcp://<%= cluster_remote_member %>:61616)" userName="amquser" password="<%= scope.lookupvar('::openshift_origin::activemq_password') %>"
+			conduitSubscriptions="false">
+			<excludedDestinations><topic physicalName=">" /></excludedDestinations>
+		</networkConnector>
+<% end -%>
+	</networkConnectors>
+
+        <plugins>
+          <statisticsBrokerPlugin/>
+          <simpleAuthenticationPlugin>
+             <users>
+               <authenticationUser username="<%= scope.lookupvar('::openshift_origin::mcollective_user') %>" password="<%= scope.lookupvar('::openshift_origin::mcollective_password') %>" groups="mcollective,everyone"/>
+               <authenticationUser username="amquser" password="<%= scope.lookupvar('::openshift_origin::activemq_password') %>" groups="admins,everyone"/>
+               <authenticationUser username="admin" password="<%= scope.lookupvar('::openshift_origin::activemq_admin_password') %>" groups="mcollective,admin,everyone"/>
+             </users>
+          </simpleAuthenticationPlugin>
+          <authorizationPlugin>
+            <map>
+              <authorizationMap>
+                <authorizationEntries>
+                  <authorizationEntry queue=">" write="admins" read="admins" admin="admins" />
+                  <authorizationEntry topic=">" write="admins" read="admins" admin="admins" />
+                  <authorizationEntry topic="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
+                  <authorizationEntry queue="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
+                  <authorizationEntry topic="ActiveMQ.Advisory.>" read="everyone" write="everyone" admin="everyone"/>
+                </authorizationEntries>
+              </authorizationMap>
+            </map>
+          </authorizationPlugin>
+        </plugins>
+
+          <!--
+            The systemUsage controls the maximum amount of space the broker will
+            use before slowing down producers. For more information, see:
+            http://activemq.apache.org/producer-flow-control.html
+            If using ActiveMQ embedded - the following limits could safely be used:
+
+        <systemUsage>
+            <systemUsage>
+                <memoryUsage>
+                    <memoryUsage limit="20 mb"/>
+                </memoryUsage>
+                <storeUsage>
+                    <storeUsage limit="1 gb"/>
+                </storeUsage>
+                <tempUsage>
+                    <tempUsage limit="100 mb"/>
+                </tempUsage>
+            </systemUsage>
+        </systemUsage>
+        -->
+          <systemUsage>
+            <systemUsage>
+                <memoryUsage>
+                    <memoryUsage limit="64 mb"/>
+                </memoryUsage>
+                <storeUsage>
+                    <storeUsage limit="100 gb"/>
+                </storeUsage>
+                <tempUsage>
+                    <tempUsage limit="50 gb"/>
+                </tempUsage>
+            </systemUsage>
+        </systemUsage>
+
+        <!--
+            The transport connectors expose ActiveMQ over a given protocol to
+            clients and other brokers. For more information, see:
+
+            http://activemq.apache.org/configuring-transports.html
+        -->
+        <transportConnectors>
+            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616"/>
+            <transportConnector name="stomp" uri="stomp://0.0.0.0:61613"/>
+        </transportConnectors>
+
+    </broker>
+
+    <!--
+        Enable web consoles, REST and Ajax APIs and demos
+
+        Take a look at ${ACTIVEMQ_HOME}/conf/jetty.xml for more details
+    -->
+    <import resource="jetty.xml"/>
+
+</beans>
+<!-- END SNIPPET: example -->

--- a/templates/mcollective/mcollective-client.cfg.erb
+++ b/templates/mcollective/mcollective-client.cfg.erb
@@ -11,9 +11,17 @@ securityprovider = psk
 plugin.psk = unset
 
 connector = activemq
-plugin.activemq.pool.size = 1
+plugin.activemq.pool.size = <%= @pool_size %>
+<% if scope.lookupvar('::openshift_origin::activemq_cluster') then
+@cluster_members.each_with_index do |cluster_member, index| -%>
+plugin.activemq.pool.<%= index + 1%>.host = <%= cluster_member %>
+plugin.activemq.pool.<%= index + 1%>.port = 61613
+plugin.activemq.pool.<%= index + 1%>.user = <%= scope.lookupvar('::openshift_origin::mcollective_user') %>
+plugin.activemq.pool.<%= index + 1%>.password = <%= scope.lookupvar('::openshift_origin::mcollective_password') %>
+<% end -%>
+<% else -%>
 plugin.activemq.pool.1.host = <%= scope.lookupvar('::openshift_origin::activemq_hostname') %>
 plugin.activemq.pool.1.port = 61613
 plugin.activemq.pool.1.user = <%= scope.lookupvar('::openshift_origin::mcollective_user') %>
 plugin.activemq.pool.1.password = <%= scope.lookupvar('::openshift_origin::mcollective_password') %>
-
+<% end -%>

--- a/templates/mcollective/mcollective-server.cfg.erb
+++ b/templates/mcollective/mcollective-server.cfg.erb
@@ -13,11 +13,20 @@ securityprovider = psk
 plugin.psk = unset
 
 connector = activemq
-plugin.activemq.pool.size = 1
+plugin.activemq.pool.size = <%= @pool_size %>
+<% if scope.lookupvar('::openshift_origin::activemq_cluster') then
+@cluster_members.each_with_index do |cluster_member, index| -%>
+plugin.activemq.pool.<%= index + 1%>.host = <%= cluster_member %>
+plugin.activemq.pool.<%= index + 1%>.port = 61613
+plugin.activemq.pool.<%= index + 1%>.user = <%= scope.lookupvar('::openshift_origin::mcollective_user') %>
+plugin.activemq.pool.<%= index + 1%>.password = <%= scope.lookupvar('::openshift_origin::mcollective_password') %>
+<% end -%>
+<% else -%>
 plugin.activemq.pool.1.host = <%= scope.lookupvar('::openshift_origin::activemq_hostname') %>
 plugin.activemq.pool.1.port = 61613
 plugin.activemq.pool.1.user = <%= scope.lookupvar('::openshift_origin::mcollective_user') %>
 plugin.activemq.pool.1.password = <%= scope.lookupvar('::openshift_origin::mcollective_password') %>
+<% end -%>
 
 # Facts
 factsource = yaml


### PR DESCRIPTION
Previously, ActiveMQ and the Mcollective client were single points
of failure on broker hosts.  This patch adds support for
clustering these services for high-availability and scalability.
