### PR TITLE
Adds MongoDB Replica Set Support

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -203,6 +203,12 @@ DNS entries for the hostnames of the other components being
 installed on this host as well. If you are using a nameserver set
 up separately, you are responsible for all necessary DNS entries.
 
+==== datastore1_ip_addr|datastore2_ip_addr|datastore3_ip_addr
+Default: undef
+
+IP addresses of the first 3 MongoDB servers in a replica set.
+Add datastoreX_ip_addr parameters for larger clusters.
+
 ==== nameserver_ip_addr
 Default: IP of a name server instance or current IP if installing on this 
 node. This is used by every node to configure its primary name server.
@@ -301,6 +307,49 @@ This is the name of the database in MongoDB in which the broker will
 store data.
 
 Default: openshift_broker
+
+==== mongodb_port
+Default: '27017'
+
+The TCP port used for MongoDB to listen on.
+
+==== mongodb_replicasets
+Default: false
+
+Enable/disable MongoDB replica sets for database high-availability.
+
+==== mongodb_replica_name
+Default: 'openshift'
+
+The MongoDB replica set name when $mongodb_replicasets is true.
+
+==== mongodb_replica_primary
+Default: undef
+
+Set the host as the primary with true or secondary with false.
+
+==== mongodb_replica_primary_ip_addr
+Default: undef
+
+The IP address of the Primary host within the MongoDB replica set.
+
+==== mongodb_replicasets_members
+Default: undef
+
+An array of [host:port] of replica set hosts.
+Example: ['10.10.10.10:27017', '10.10.10.11:27017', '10.10.10.12:27017']
+
+==== mongodb_keyfile
+Default: '/etc/mongodb.keyfile'
+
+The file containing the $mongodb_key used to authenticate MongoDB
+replica set members.
+
+==== mongodb_key
+Default: 'changeme'
+
+The key used by members of a MongoDB replica set to authenticate
+one another.
 
 ==== openshift_user1
 ==== openshift_password1

--- a/configure_origin.pp.mongo_replset.example
+++ b/configure_origin.pp.mongo_replset.example
@@ -1,0 +1,62 @@
+  $my_hostname='<BROKER01_FQDN>'
+
+  exec { "set_hostname":
+    command => "/bin/hostname ${my_hostname}",
+    unless  => "/bin/hostname | /bin/grep ${my_hostname}",
+  }
+
+  if $::operatingsystem == 'Fedora' {
+    exec { "set_etc_hostname":
+      command => "/bin/echo ${my_hostname} > /etc/hostname",
+      unless  => "/bin/grep ${my_hostname} /etc/hostname",
+    }
+  }
+
+  if $::operatingsystem == 'CentOS' {
+    exec { "set_etc_hostname":
+      command => "/bin/sed -ri \'s/HOSTNAME=.*/HOSTNAME=${my_hostname}/\' /etc/sysconfig/network",
+      unless  => "/bin/grep ${my_hostname} /etc/sysconfig/network",
+    }
+  }
+
+class { 'openshift_origin' :
+  # Mongo Replication
+  mongodb_replicasets             => true,
+  mongodb_replica_primary         => true, # Set to false for secondary mongo servers
+  mongodb_replica_primary_ip_addr => '<PRIMARY_IP>', # i.e. broker01 IP address
+  # <IP>:<Port> of MongoDB replication members.
+  mongodb_replicasets_members     => ['<MEMBER1_IP>:<MONGO_PORT>', '<MEMBER2_IP>:<MONGO_PORT>', '<MEMBER3_IP>:<MONGO_PORT>'],
+  mongodb_key                     => '<MONGODB_REPL_KEY>',
+  datastore1_ip_addr              => '<MEMBER1_IP>',
+  datastore2_ip_addr              => '<MEMBER2_IP>',
+  datastore3_ip_addr              => '<MEMBER3_IP>',
+  
+  # Components to install on this host:
+  roles                           => ['broker','nameserver','msgserver','datastore'],
+  # BIND / nameserver config
+  # This is the key for updating the OpenShift BIND server
+  bind_key                        => '<DNSSEC_BIND_KEY>',
+  # The domain under which applications should be created.
+  domain                          => '<FQDN>',
+  # Apps would be nameserver <app>-<namespace>.example.com
+  # This also creates hostnames for local components under our domain
+  register_host_with_nameserver   => true,
+  # Forward requests for other domains (to Google by default)
+  conf_nameserver_upstream_dns    => ['<UPSTREAM_DNS_IP>'],
+  # NTP Servers for OpenShift hosts to sync time
+  ntp_servers                     => ["<UPSTREAM_NTP_FQDN> iburst"],
+  # The FQDNs of the OpenShift component hosts
+  broker_hostname                 => $my_hostname,
+  nameserver_hostname             => $my_hostname,
+  datastore_hostname              => $my_hostname,
+  msgserver_hostname              => $my_hostname,
+  # Auth OpenShift users created with htpasswd tool in /etc/openshift/htpasswd
+  broker_auth_plugin              => 'htpasswd',
+  # Username and password for initial openshift user
+  openshift_user1                 => 'openshift',
+  openshift_password1             => 'password',
+  #Enable development mode for more verbose logs
+  development_mode                => true,
+  # Set if using an external-facing ethernet device other than eth0
+  conf_node_external_eth_dev      => 'eth0',
+}

--- a/manifests/datastore.pp
+++ b/manifests/datastore.pp
@@ -25,6 +25,8 @@ class openshift_origin::datastore {
 
   # TODO: See about replacing with Mongo Puppet module
 
+  $port = $openshift_origin::mongodb_port
+
   file { 'mongo setup script':
     ensure  => present,
     path    => '/usr/sbin/oo-mongo-setup',
@@ -74,6 +76,46 @@ class openshift_origin::datastore {
         File['mongo setup script'],
         Class['openshift_origin::update_conf_files'],
       ],
+    }
+  }
+
+  if $openshift_origin::mongodb_replicasets {
+    file { $openshift_origin::mongodb_keyfile:
+      content => inline_template($openshift_origin::mongodb_key),
+      owner   => 'mongodb',
+      group   => 'mongodb',
+      mode    => '0400',
+      require => Exec['/usr/sbin/oo-mongo-setup'],
+      notify  => Service['mongod'],
+    }
+    exec { 'keyfile-mongo-conf':
+      path    => ['/bin/', '/usr/bin/', '/usr/sbin/'],
+      command => "echo -e \"\nkeyFile = $openshift_origin::mongodb_keyfile\n\" >> /etc/mongodb.conf",
+      unless  => "grep \"keyFile = $openshift_origin::mongodb_keyfile\" /etc/mongodb.conf",
+      require => File[$openshift_origin::mongodb_keyfile],
+      notify  => Service['mongod'],
+    }
+    exec { 'replset-mongo-conf':
+      path    => ['/bin/', '/usr/bin/', '/usr/sbin/'],
+      command => "echo -e \"\nreplSet = $openshift_origin::mongodb_replica_name\n\" >> /etc/mongodb.conf",
+      unless  => "grep \"replSet = $openshift_origin::mongodb_replica_name\" /etc/mongodb.conf",
+      require => [File[$openshift_origin::mongodb_keyfile],Exec['/usr/sbin/oo-mongo-setup']],
+      notify  => Service['mongod'],
+    }
+    if $openshift_origin::mongodb_replica_primary {
+      exec { 'replset-init':
+        path    => ['/bin/', '/usr/bin/', '/usr/sbin/'],
+        command => "mongo admin -u $openshift_origin::mongodb_admin_user -p $openshift_origin::mongodb_admin_password --quiet --eval printjson\"(rs.initiate({ _id: \'$openshift_origin::mongodb_replica_name\', members: [ { _id: 0, host: \'${ipaddress}:${port}\' } ] }))\"",
+        unless  => "mongo admin --host $ipaddress -u $openshift_origin::mongodb_admin_user -p $openshift_origin::mongodb_admin_password --quiet --eval \"printjson(rs.status())\" | grep '\"name\" : \"${ipaddress}:${port}\"'",
+        require => [Service['mongod'], Exec['keyfile-mongo-conf', 'replset-mongo-conf']],
+      }
+    } else {
+      exec { 'replset-add':
+        path    => ['/bin/', '/usr/bin/', '/usr/sbin/'],
+        command => "mongo admin --host $openshift_origin::mongodb_replica_primary_ip_addr -u $openshift_origin::mongodb_admin_user -p $openshift_origin::mongodb_admin_password --quiet --eval \"printjson(rs.add(\'${ipaddress}:${port}\'))\"",
+        unless  => "mongo admin --host $openshift_origin::mongodb_replica_primary_ip_addr -u $openshift_origin::mongodb_admin_user -p $openshift_origin::mongodb_admin_password --quiet --eval \"printjson(rs.status())\" | grep '\"name\" : \"${ipaddress}:${port}\"'",
+        require => [Service['mongod'], Exec['keyfile-mongo-conf', 'replset-mongo-conf']],
+      }
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,6 +107,11 @@
 #   installed on this host as well. If you are using a nameserver set
 #   up separately, you are responsible for all necessary DNS entries.
 #
+# [*datastore1_ip_addr|datastore2_ip_addr|datastore3_ip_addr*]
+#   Default: undef
+#   IP addresses of the first 3 MongoDB servers in a replica set.
+#   Add datastoreX_ip_addr parameters for larger clusters.
+# 
 # [*nameserver_ip_addr*]
 #   Default: IP of a nameserver instance or current IP if installing on this
 #   node. This is used by every node to configure its primary name server.
@@ -208,6 +213,41 @@
 #   Default: openshift_broker
 #   This is the name of the database in MongoDB in which the broker will
 #   store data.
+# 
+# [*mongodb_port*]
+#   Default: '27017'
+#   The TCP port used for MongoDB to listen on.
+#
+# [*mongodb_replicasets*]
+#   Default: false
+#   Enable/disable MongoDB replica sets for database high-availability.
+#
+# [*mongodb_replica_name*]
+#   Default: 'openshift'
+#   The MongoDB replica set name when $mongodb_replicasets is true.
+#
+# [*mongodb_replica_primary*]
+#   Default: undef
+#   Set the host as the primary with true or secondary with false.
+#
+# [*mongodb_replica_primary_ip_addr*]
+#   Default: undef
+#   The IP address of the Primary host within the MongoDB replica set.
+#
+# [*mongodb_replicasets_members*]
+#   Default: undef
+#   An array of [host:port] of replica set hosts. Example:
+#   ['10.10.10.10:27017', '10.10.10.11:27017', '10.10.10.12:27017']
+#
+# [*mongodb_keyfile*]
+#   Default: '/etc/mongodb.keyfile'
+#   The file containing the $mongodb_key used to authenticate MongoDB
+#   replica set members.
+#
+# [*mongodb_key*]
+#   Default: 'changeme'
+#   The key used by members of a MongoDB replica set to authenticate
+#   one another.
 #
 # [*openshift_user1*]
 # [*openshift_password1*]
@@ -489,6 +529,9 @@ class openshift_origin (
   $nameserver_hostname                  = "ns1.${domain}",
   $msgserver_hostname                   = "msgserver.${domain}",
   $datastore_hostname                   = "mongodb.${domain}",
+  $datastore1_ip_addr                   = undef,
+  $datastore2_ip_addr                   = undef,
+  $datastore3_ip_addr                   = undef,
   $nameserver_ip_addr                   = $ipaddress,
   $bind_key                             = '',
   $bind_krb_keytab                      = '',
@@ -508,6 +551,14 @@ class openshift_origin (
   $mongodb_broker_user                  = 'openshift',
   $mongodb_broker_password              = 'mongopass',
   $mongodb_name                         = 'openshift_broker',
+  $mongodb_port                         = '27017',
+  $mongodb_replicasets                  = false,
+  $mongodb_replica_name                 = 'openshift',
+  $mongodb_replica_primary              = undef,
+  $mongodb_replica_primary_ip_addr      = undef,
+  $mongodb_replicasets_members          = undef,
+  $mongodb_keyfile                      = '/etc/mongodb.keyfile',
+  $mongodb_key                          = 'changeme',
   $openshift_user1                      = 'demo',
   $openshift_password1                  = 'changeme',
   $conf_broker_auth_salt                = inline_template('<%= require "securerandom"; SecureRandom.base64 %>'),

--- a/templates/broker/broker.conf.erb
+++ b/templates/broker/broker.conf.erb
@@ -14,9 +14,14 @@ DEFAULT_GEAR_CAPABILITIES="<%= scope.lookupvar('::openshift_origin::conf_default
 DEFAULT_GEAR_SIZE="<%= scope.lookupvar('::openshift_origin::conf_default_gear_size') %>"
 
 #Broker datastore configuration
-MONGO_REPLICA_SETS=false
+MONGO_REPLICA_SETS=<%= scope.lookupvar('::openshift_origin::mongodb_replicasets') %>
+<% if scope.lookupvar('::openshift_origin::mongodb_replicasets') == true %>
+# Replica set example: "<host-1>:<port-1> <host-2>:<port-2> ..."
+MONGO_HOST_PORT="<%= scope.lookupvar('::openshift_origin::mongodb_replicasets_members').join(',') %>"
+<% else %>
 # Replica set example: "<host-1>:<port-1> <host-2>:<port-2> ..."
 MONGO_HOST_PORT="<%= scope.lookupvar('::openshift_origin::datastore_hostname') %>:27017"
+<% end %>
 MONGO_USER="<%= scope.lookupvar('::openshift_origin::mongodb_broker_user') %>"
 MONGO_PASSWORD="<%= scope.lookupvar('::openshift_origin::mongodb_broker_password') %>"
 MONGO_DB="<%= scope.lookupvar('::openshift_origin::mongodb_name') %>"

--- a/templates/broker/plugins/auth/mongo/mongo.conf.plugin.erb
+++ b/templates/broker/plugins/auth/mongo/mongo.conf.plugin.erb
@@ -1,6 +1,11 @@
-MONGO_REPLICA_SETS=false
+MONGO_REPLICA_SETS=<%= scope.lookupvar('::openshift_origin::mongodb_replicasets') %>
+<% if scope.lookupvar('::openshift_origin::mongodb_replicasets') == true %>
+# Replica set example: "<host-1>:<port-1> <host-2>:<port-2> ..."
+MONGO_HOST_PORT="<%= scope.lookupvar('::openshift_origin::mongodb_replicasets_members').join(',') %>"
+<% else %>
 # Replica set example: "<host-1>:<port-1> <host-2>:<port-2> ..."
 MONGO_HOST_PORT="<%= scope.lookupvar('::openshift_origin::datastore_hostname') %>:27017"
+<% end %>
 MONGO_USER="<%= scope.lookupvar('::openshift_origin::mongodb_broker_user') %>"
 MONGO_PASSWORD="<%= scope.lookupvar('::openshift_origin::mongodb_broker_password') %>"
 MONGO_DB="<%= scope.lookupvar('::openshift_origin::mongodb_name') %>"


### PR DESCRIPTION
Previously, the openshift puppet module only supported a single
datastore host.  This patch adds support for MongoDB replica sets.

The patch supports deploying replica set members with a single
puppet run.
