### PR TITLE
Adds Support for Clustering ActiveMQ & Mcollective

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -262,6 +262,31 @@ Default: ['time.apple.com iburst', 'pool.ntp.org iburst', 'clock.redhat.com ibur
 NOTE: Use iburst after every ntp server definition to speed up the
 initial synchronization.
 
+==== msgserver_cluster
+Default: false
+
+Set to true to cluster ActiveMQ for high-availability and scalability
+of OpenShift message queues.
+
+==== msgserver_cluster_members
+Default: undef
+
+An array of ActiveMQ server hostnames to be included in the ActiveMQ
+cluster. Required when parameter msgserver_cluster is set to true.
+
+==== mcollective_cluster_members
+Default: $msgserver_cluster_members
+
+An array of ActiveMQ server hostnames to be included in the ActiveMQ
+cluster. Required when parameter msgserver_cluster is set to true.
+
+==== msgserver_password
+Default 'changeme'
+
+Password used by ActiveMQ's amquser.  The amquser is used to authenticate
+ActiveMQ inter-cluster communication.  Only used when msgserver_cluster
+is true.
+
 ==== msgserver_admin_password
 This is the admin password for the ActiveMQ admin console, which is
 not needed by OpenShift but might be useful in troubleshooting.

--- a/configure_origin.pp.broker_example
+++ b/configure_origin.pp.broker_example
@@ -30,4 +30,9 @@ class { 'openshift_origin' :
 
   #Enable development mode for more verbose logs
   development_mode           => true,
+
+  # Uncomment msgserver_cluster and msgserver_cluster_members for ActiveMQ High-Availability
+  # Clustering requires a minimum of 3 servers.
+  #msgserver_cluster         => true,
+  #msgserver_cluster_members => ['<MSGSERVER_HOSTNAME01>', '<MSGSERVER_HOSTNAME02>', '<MSGSERVER_HOSTNAME03>'],
 }

--- a/manifests/firewall/activemq.pp
+++ b/manifests/firewall/activemq.pp
@@ -2,4 +2,10 @@ class openshift_origin::firewall::activemq {
   lokkit::ports { 'ActiveMQ':
     tcpPorts => [ '61613' ],
   }
+
+  if $::openshift_origin::msgserver_cluster {
+    lokkit::ports { 'ActiveMQ-Openwire':
+      tcpPorts => [ '61616' ],
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -173,6 +173,27 @@
 # only alphanumeric values in this script as others may cause syntax
 # errors depending on context. If non-alphanumeric values are required,
 # update them separately after installation.
+# 
+# [*msgserver_cluster*]
+#   Default: false
+#   Set to true to cluster ActiveMQ for high-availability and scalability
+#   of OpenShift message queues.
+#
+# [*msgserver_cluster_members*]
+#   Default: undef
+#   An array of ActiveMQ server hostnames.  Required when parameter
+#   msgserver_cluster is set to true.
+#
+# [*mcollective_cluster_members*]
+#   Default: $msgserver_cluster_members
+#   An array of ActiveMQ server hostnames.  Required when parameter
+#   msgserver_cluster is set to true.
+#
+# [*msgserver_password*]
+#   Default 'changeme'
+#   Password used by ActiveMQ's amquser.  The amquser is used to authenticate
+#   ActiveMQ inter-cluster communication.  Only used when msgserver_cluster
+#   is true.
 #
 # [*msgserver_admin_password*]
 #   Default: scrambled
@@ -500,6 +521,10 @@ class openshift_origin (
   $node_ip_addr                         = $ipaddress,
   $configure_ntp                        = true,
   $ntp_servers                          = ['time.apple.com iburst', 'pool.ntp.org iburst', 'clock.redhat.com iburst'],
+  $msgserver_cluster                    = false,
+  $msgserver_cluster_members            = undef,
+  $mcollective_cluster_members          = $msgserver_cluster_members,
+  $msgserver_password                   = 'changeme',
   $msgserver_admin_password             = inline_template('<%= require "securerandom"; SecureRandom.base64 %>'),
   $mcollective_user                     = 'mcollective',
   $mcollective_password                 = 'marionette',
@@ -547,6 +572,11 @@ class openshift_origin (
   $manage_firewall                      = true,
 ){
   include openshift_origin::role
+
+  if $msgserver_cluster and ! $msgserver_cluster_members and ! $mcollective_cluster_members {
+    fail('msgserver_cluster_members and mcollective_cluster_members parameters are required when msgserver_cluster is set')
+  }
+
   if member( $roles, 'nameserver' ) {
     class{ 'openshift_origin::role::nameserver':
       before => Class['openshift_origin::update_conf_files'],

--- a/manifests/mcollective_client.pp
+++ b/manifests/mcollective_client.pp
@@ -23,6 +23,14 @@ class openshift_origin::mcollective_client {
 
   # TODO: Replace with MCollective puppet module call
 
+  $cluster_members = $::openshift_origin::mcollective_cluster_members
+
+  if $cluster_members {
+    $pool_size = size($cluster_members)
+  } else {
+    $pool_size = '1'
+  }
+
   file { 'mcollective client config':
     ensure  => present,
     path    => "${::openshift_origin::params::ruby_scl_path_prefix}/etc/mcollective/client.cfg",

--- a/manifests/mcollective_server.pp
+++ b/manifests/mcollective_server.pp
@@ -21,6 +21,14 @@ class openshift_origin::mcollective_server {
     require => Class['openshift_origin::install_method'],
   }
 
+  $cluster_members = $::openshift_origin::mcollective_cluster_members
+
+  if $cluster_members {
+    $pool_size = size($cluster_members)
+  } else {
+    $pool_size = '1'
+  }
+
   # Ensure classes are run in order
   Class['Openshift_origin::Role']              -> Class['Openshift_origin::Mcollective_server']
   Class['Openshift_origin::Update_conf_files'] -> Class['Openshift_origin::Mcollective_server']

--- a/manifests/msgserver.pp
+++ b/manifests/msgserver.pp
@@ -21,6 +21,9 @@ class openshift_origin::msgserver (
     include openshift_origin::firewall::activemq
   }
 
+  $cluster_members        = $::openshift_origin::msgserver_cluster_members
+  $cluster_remote_members = delete($cluster_members, $::openshift_origin::msgserver_hostname)
+
   package { ['activemq','activemq-client']:
       ensure  => present,
       require => Class['openshift_origin::install_method'],
@@ -50,9 +53,15 @@ class openshift_origin::msgserver (
     require => Package['activemq'],
   }
 
+  if $::openshift_origin::msgserver_cluster {
+    $activemq_config_template_real = 'openshift_origin/activemq/activemq-network.xml.erb'
+  } else {
+    $activemq_config_template_real = 'openshift_origin/activemq/activemq.xml.erb'
+  }
+
   file { 'activemq.xml config':
     path    => '/etc/activemq/activemq.xml',
-    content => template('openshift_origin/activemq/activemq.xml.erb'),
+    content => template($activemq_config_template_real),
     owner   => 'root',
     group   => 'root',
     mode    => '0444',

--- a/templates/activemq/activemq-network.xml.erb
+++ b/templates/activemq/activemq-network.xml.erb
@@ -1,0 +1,158 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:amq="http://activemq.apache.org/schema/core"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+  http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+    <!-- Allows us to use system properties as variables in this configuration file -->
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="locations">
+            <value>file:${activemq.conf}/credentials.properties</value>
+        </property>
+    </bean>
+
+    <!--
+        The <broker> element is used to configure the ActiveMQ broker.
+    -->
+    <broker xmlns="http://activemq.apache.org/schema/core"
+	    brokerName="<%= scope.lookupvar('::openshift_origin::msgserver_hostname') %>"
+	    useJmx="true"
+	    dataDirectory="${activemq.data}"
+            schedulePeriodForDestinationPurge="60000">
+        <!--
+            For better performances use VM cursor and small memory limit.
+            For more information, see:
+            http://activemq.apache.org/message-cursors.html
+        -->
+
+        <destinationPolicy>
+		<policyMap>
+			<policyEntries>
+				<policyEntry topic=">" producerFlowControl="false"/>
+				<policyEntry queue="*.reply.>" gcInactiveDestinations="true"
+					inactiveTimoutBeforeGC="300000" />
+			</policyEntries>
+		</policyMap>
+        </destinationPolicy>
+
+
+        <!--
+            The managementContext is used to configure how ActiveMQ is exposed in
+            JMX. By default, ActiveMQ uses the MBean server that is started by
+            the JVM. For more information, see:
+
+            http://activemq.apache.org/jmx.html
+        -->
+        <managementContext>
+            <managementContext createConnector="false"/>
+        </managementContext>
+
+	<networkConnectors>
+<% @cluster_remote_members.each do |cluster_remote_member| -%>
+		<networkConnector name="<%= scope.lookupvar('::openshift_origin::msgserver_hostname') %>-<%= cluster_remote_member %>-topic" uri="static:(tcp://<%= cluster_remote_member %>:61616)" userName="amquser" password="<%= scope.lookupvar('::openshift_origin::msgserver_password') %>">
+			<excludedDestinations><queue physicalName=">" /></excludedDestinations>
+		</networkConnector>
+		<networkConnector name="<%= scope.lookupvar('::openshift_origin::msgserver_hostname') %>-<%= cluster_remote_member %>-queue" uri="static:(tcp://<%= cluster_remote_member %>:61616)" userName="amquser" password="<%= scope.lookupvar('::openshift_origin::msgserver_password') %>"
+			conduitSubscriptions="false">
+			<excludedDestinations><topic physicalName=">" /></excludedDestinations>
+		</networkConnector>
+<% end -%>
+	</networkConnectors>
+
+        <plugins>
+          <statisticsBrokerPlugin/>
+          <simpleAuthenticationPlugin>
+             <users>
+               <authenticationUser username="<%= scope.lookupvar('::openshift_origin::mcollective_user') %>" password="<%= scope.lookupvar('::openshift_origin::mcollective_password') %>" groups="mcollective,everyone"/>
+               <authenticationUser username="amquser" password="<%= scope.lookupvar('::openshift_origin::msgserver_password') %>" groups="admins,everyone"/>
+               <authenticationUser username="admin" password="<%= scope.lookupvar('::openshift_origin::msgserver_admin_password') %>" groups="mcollective,admin,everyone"/>
+             </users>
+          </simpleAuthenticationPlugin>
+          <authorizationPlugin>
+            <map>
+              <authorizationMap>
+                <authorizationEntries>
+                  <authorizationEntry queue=">" write="admins" read="admins" admin="admins" />
+                  <authorizationEntry topic=">" write="admins" read="admins" admin="admins" />
+                  <authorizationEntry topic="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
+                  <authorizationEntry queue="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
+                  <authorizationEntry topic="ActiveMQ.Advisory.>" read="everyone" write="everyone" admin="everyone"/>
+                </authorizationEntries>
+              </authorizationMap>
+            </map>
+          </authorizationPlugin>
+        </plugins>
+
+          <!--
+            The systemUsage controls the maximum amount of space the broker will
+            use before slowing down producers. For more information, see:
+            http://activemq.apache.org/producer-flow-control.html
+            If using ActiveMQ embedded - the following limits could safely be used:
+
+        <systemUsage>
+            <systemUsage>
+                <memoryUsage>
+                    <memoryUsage limit="20 mb"/>
+                </memoryUsage>
+                <storeUsage>
+                    <storeUsage limit="1 gb"/>
+                </storeUsage>
+                <tempUsage>
+                    <tempUsage limit="100 mb"/>
+                </tempUsage>
+            </systemUsage>
+        </systemUsage>
+        -->
+          <systemUsage>
+            <systemUsage>
+                <memoryUsage>
+                    <memoryUsage limit="64 mb"/>
+                </memoryUsage>
+                <storeUsage>
+                    <storeUsage limit="100 gb"/>
+                </storeUsage>
+                <tempUsage>
+                    <tempUsage limit="50 gb"/>
+                </tempUsage>
+            </systemUsage>
+        </systemUsage>
+
+        <!--
+            The transport connectors expose ActiveMQ over a given protocol to
+            clients and other brokers. For more information, see:
+
+            http://activemq.apache.org/configuring-transports.html
+        -->
+        <transportConnectors>
+            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616"/>
+            <transportConnector name="stomp" uri="stomp://0.0.0.0:61613"/>
+        </transportConnectors>
+
+    </broker>
+
+    <!--
+        Enable web consoles, REST and Ajax APIs and demos
+
+        Take a look at ${ACTIVEMQ_HOME}/conf/jetty.xml for more details
+    -->
+    <import resource="jetty.xml"/>
+
+</beans>
+<!-- END SNIPPET: example -->

--- a/templates/mcollective/mcollective-client.cfg.erb
+++ b/templates/mcollective/mcollective-client.cfg.erb
@@ -11,9 +11,17 @@ securityprovider = psk
 plugin.psk = unset
 
 connector = activemq
-plugin.activemq.pool.size = 1
+plugin.activemq.pool.size = <%= @pool_size %>
+<% if scope.lookupvar('::openshift_origin::msgserver_cluster') then
+@cluster_members.each_with_index do |cluster_member, index| -%>
+plugin.activemq.pool.<%= index + 1%>.host = <%= cluster_member %>
+plugin.activemq.pool.<%= index + 1%>.port = 61613
+plugin.activemq.pool.<%= index + 1%>.user = <%= scope.lookupvar('::openshift_origin::mcollective_user') %>
+plugin.activemq.pool.<%= index + 1%>.password = <%= scope.lookupvar('::openshift_origin::mcollective_password') %>
+<% end -%>
+<% else -%>
 plugin.activemq.pool.1.host = <%= scope.lookupvar('::openshift_origin::msgserver_hostname') %>
 plugin.activemq.pool.1.port = 61613
 plugin.activemq.pool.1.user = <%= scope.lookupvar('::openshift_origin::mcollective_user') %>
 plugin.activemq.pool.1.password = <%= scope.lookupvar('::openshift_origin::mcollective_password') %>
-
+<% end -%>

--- a/templates/mcollective/mcollective-server.cfg.erb
+++ b/templates/mcollective/mcollective-server.cfg.erb
@@ -13,11 +13,20 @@ securityprovider = psk
 plugin.psk = unset
 
 connector = activemq
-plugin.activemq.pool.size = 1
+plugin.activemq.pool.size = <%= @pool_size %>
+<% if scope.lookupvar('::openshift_origin::msgserver_cluster') then
+@cluster_members.each_with_index do |cluster_member, index| -%>
+plugin.activemq.pool.<%= index + 1%>.host = <%= cluster_member %>
+plugin.activemq.pool.<%= index + 1%>.port = 61613
+plugin.activemq.pool.<%= index + 1%>.user = <%= scope.lookupvar('::openshift_origin::mcollective_user') %>
+plugin.activemq.pool.<%= index + 1%>.password = <%= scope.lookupvar('::openshift_origin::mcollective_password') %>
+<% end -%>
+<% else -%>
 plugin.activemq.pool.1.host = <%= scope.lookupvar('::openshift_origin::msgserver_hostname') %>
 plugin.activemq.pool.1.port = 61613
 plugin.activemq.pool.1.user = <%= scope.lookupvar('::openshift_origin::mcollective_user') %>
 plugin.activemq.pool.1.password = <%= scope.lookupvar('::openshift_origin::mcollective_password') %>
+<% end -%>
 
 # Facts
 factsource = yaml


### PR DESCRIPTION
Previously, ActiveMQ and the Mcollective were single points of
failure.  This patch adds support for clustering these services
for high-availability and scalability.
