### PR TITLE
Ensure ntp is installed, not latest

### DIFF
--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -25,8 +25,7 @@ class openshift_origin::role {
       ensure => 'present',
     }
     class { 'ntp':
-      servers        => $::openshift_origin::ntp_servers,
-      package_ensure => 'latest',
+      servers => $::openshift_origin::ntp_servers,
     }
   }
 }


### PR DESCRIPTION
Fixes GH-59, which states:

This is a very quick way to an unstable system and prevents controlling when
updates are conducted.

An example scenario is when new packages make it to the repos but they config
requirements have also changed. Anyone using this module will have their
origin install begin to fail on the next puppet run until they figure out they
need to update the module and only then would their install start working
again.

Another case is where a system under use probably needs to be update during
off hours to allow maximum uptime durring the day.

Instead change all package resources to read ensure => present which allows
the administrator to update the module and the packages during a planned
window.
