### PR TITLE
Declare resource for reloading systemd

### DIFF
--- a/manifests/mcollective_server.pp
+++ b/manifests/mcollective_server.pp
@@ -45,6 +45,11 @@ class openshift_origin::mcollective_server {
   }
 
   if( $::operatingsystem == 'Fedora' ) {
+    exec { 'systemd-daemon-reload':
+      command     => '/usr/bin/systemctl daemon-reload',
+      refreshonly => true,
+    }
+
     $require_real = [
       File['mcollective server config', '/usr/lib/systemd/system/mcollective.service'],
       Exec['systemd-daemon-reload']


### PR DESCRIPTION
The setup is failing on Fedora 19 x86_64.
