### PR TITLE
Allow the option to not update resolv.conf and network options. This is ...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -514,6 +514,11 @@
 # [*manage_firewall*]
 #   Indicate whether or not this module will configure the firewall for you
 #
+# [*update_conf_files*]
+#   Indicate whether or not this module will configure resolv.conf and
+#   network for you. In some cases, especially in enterprise, dns and network 
+#   are defined through other mechanisms
+#
 # [*install_cartridges*]
 #   List of cartridges to be installed on the node. Options:
 #

--- a/manifests/update_conf_files.pp
+++ b/manifests/update_conf_files.pp
@@ -13,29 +13,31 @@
 #  limitations under the License.
 #
 class openshift_origin::update_conf_files {
-  augeas { 'network-scripts':
-    context => "/files/etc/sysconfig/network-scripts/ifcfg-${::openshift_origin::conf_node_external_eth_dev}",
-    lens    => 'Shellvars.lns',
-    incl    => "/etc/sysconfig/network-scripts/ifcfg-${::openshift_origin::conf_node_external_eth_dev}",
-    changes => [
-      'set PEERDNS no',
-      "set DNS1 ${::openshift_origin::nameserver_ip_addr}",
-    ],
-  }
+  if $::openshift_origin::update_conf_files {
+    augeas { 'network-scripts':
+      context => "/files/etc/sysconfig/network-scripts/ifcfg-${::openshift_origin::conf_node_external_eth_dev}",
+      lens    => 'Shellvars.lns',
+      incl    => "/etc/sysconfig/network-scripts/ifcfg-${::openshift_origin::conf_node_external_eth_dev}",
+      changes => [
+        'set PEERDNS no',
+        "set DNS1 ${::openshift_origin::nameserver_ip_addr}",
+      ],
+    }
 
-  file { 'dhcpclient':
-    ensure  => present,
-    path    => "/etc/dhcp/dhclient-${::openshift_origin::conf_node_external_eth_dev}.conf",
-    content => template('openshift_origin/dhclient_conf.erb'),
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-  }
+    file { 'dhcpclient':
+      ensure  => present,
+      path    => "/etc/dhcp/dhclient-${::openshift_origin::conf_node_external_eth_dev}.conf",
+      content => template('openshift_origin/dhclient_conf.erb'),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+    }
 
-  file { '/etc/resolv.conf':
-    content => template('openshift_origin/resolv.conf.erb'),
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
+    file { '/etc/resolv.conf':
+      content => template('openshift_origin/resolv.conf.erb'),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+    }
   }
 }


### PR DESCRIPTION
...useful for enterprise environments where those options are possibly managed though other config management options and may not be ideal for the particular openshift deployment.
