### PR TITLE
Ensure that Avahi services are running

### DIFF
--- a/manifests/plugins/dns/avahi.pp
+++ b/manifests/plugins/dns/avahi.pp
@@ -54,11 +54,16 @@ class openshift_origin::plugins::dns::avahi {
     require => Class['openshift_origin::install_method'],
   }
 
-  service { ['avahi-daemon', 'avahi-cname-manager']:
+  service { 'avahi-cname-manager':
+    ensure    => running,
+    enable    => true,
+    subscribe => File['avahi-cname-manager config'],
+    require   => Package['avahi-cname-manager'],
+  }
+
+  service { 'avahi-daemon':
+    ensure  => running,
     enable  => true,
-    require => [
-      Package['avahi'],
-      Package['avahi-cname-manager'],
-    ]
+    require => Package['avahi'],
   }
 }


### PR DESCRIPTION
Ensure that Avahi services are running in openshift_origin::plugins::dns::avahi
the same way that they were in openshift_origin::avahi.
