### PR TITLE
Add v8314 to dynamic linker path when calling rake assets:precompile

### DIFF
--- a/manifests/console.pp
+++ b/manifests/console.pp
@@ -117,7 +117,7 @@ class openshift_origin::console {
   # while still invoking ruby commands in the correct context
   $console_asset_rake_cmd = $::operatingsystem ? {
     'Fedora' => '/usr/bin/rake assets:precompile',
-    default  => 'LD_LIBRARY_PATH=/opt/rh/ruby193/root/usr/lib64 GEM_PATH=/opt/rh/ruby193/root/usr/local/share/gems:/opt/rh/ruby193/root/usr/share/gems /opt/rh/ruby193/root/usr/bin/rake assets:precompile',
+    default  => 'LD_LIBRARY_PATH=/opt/rh/ruby193/root/usr/lib64:/opt/rh/v8314/root/usr/lib64 GEM_PATH=/opt/rh/ruby193/root/usr/local/share/gems:/opt/rh/ruby193/root/usr/share/gems /opt/rh/ruby193/root/usr/bin/rake assets:precompile',
   }
 
   $console_bundle_show    = $::operatingsystem ? {


### PR DESCRIPTION
rake assets:precompile fails because therubyracer cannot find v8314. Because we're not using 'scl enable', add v8314 to LD_LIBRARY_PATH.
