### PR TITLE
Fixed a bug which appears when hostname contains a point (.)

### DIFF
--- a/templates/named/dynamic-zone.db.erb
+++ b/templates/named/dynamic-zone.db.erb
@@ -10,6 +10,6 @@ $TTL 1800
                      NS <%= scope.lookupvar('::openshift_origin::nameserver_hostname') %>.
 $ORIGIN <%= scope.lookupvar('::openshift_origin::domain') %>.
 <% if scope.lookupvar('::openshift_origin::nameserver_hostname').end_with?(scope.lookupvar('::openshift_origin::domain')) %>
-<%= scope.lookupvar('::openshift_origin::nameserver_hostname').gsub('.'+scope.lookupvar('::openshift_origin::domain'),'') %>	              A        <%= scope.lookupvar('::openshift_origin::nameserver_ip_addr') %>
+<%= scope.lookupvar('::openshift_origin::nameserver_hostname') %>.  A <%= scope.lookupvar('::openshift_origin::nameserver_ip_addr') %>
 <% end %>
 


### PR DESCRIPTION
Author: Antoine Abélard
Date:   Mon Aug 04 14:29:00 2014 +0100

With the current implementation, the OpenShift Origin deployment fails when there is point (.) in the hostname.
This new implementation fix this bug.
