### PR TITLE
Mcollective client.cfg should be owned by apache:apache

### DIFF
--- a/manifests/mcollective_client.pp
+++ b/manifests/mcollective_client.pp
@@ -36,7 +36,7 @@ class openshift_origin::mcollective_client {
     path    => "${::openshift_origin::params::ruby_scl_path_prefix}/etc/mcollective/client.cfg",
     content => template('openshift_origin/mcollective/mcollective-client.cfg.erb'),
     owner   => 'apache',
-    group   => 'root',
+    group   => 'apache',
     mode    => '0640',
     require => Package['mcollective-client'],
   }


### PR DESCRIPTION
oo-accept-broker keeps complaining:
FAIL: ERROR: /opt/rh/ruby193/root/etc/mcollective/client.cfg should be owned by apache:apache
