### PR TITLE
Remove deprecated 'topicprefix' option

### DIFF
--- a/templates/mcollective/mcollective-client.cfg.erb
+++ b/templates/mcollective/mcollective-client.cfg.erb
@@ -1,4 +1,3 @@
-topicprefix = /topic/
 main_collective = mcollective
 collectives = mcollective
 libdir = <%= scope.lookupvar('::openshift_origin::params::ruby_scl_path_prefix') %>/usr/libexec/mcollective

--- a/templates/mcollective/mcollective-server.cfg.erb
+++ b/templates/mcollective/mcollective-server.cfg.erb
@@ -1,4 +1,3 @@
-topicprefix = /topic/
 main_collective = mcollective
 collectives = mcollective
 libdir = <%= scope.lookupvar('::openshift_origin::params::ruby_scl_path_prefix') %>/usr/libexec/mcollective


### PR DESCRIPTION
`block in loadconfig' Use of deprecated 'topicprefix' option.  This option is ignored and should be removed from '/opt/rh/ruby193/root/etc/mcollective/client.cfg'
