### PR TITLE
Do not add comment to cgconfig.conf

### DIFF
--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -176,9 +176,7 @@ class openshift_origin::node {
         'set freezer /cgroup/freezer',
         'set memory /cgroup/memory',
         'set net_cls /cgroup/net_cls',
-        'set #comment \'Managed by puppet:openshift_origin\'',
       ],
-      onlyif  => 'match *[#comment=\'Managed by puppet:openshift_origin\'] size == 0',
       notify  => Exec['prepare cgroups'],
     }
 


### PR DESCRIPTION
Since we've had multiple reports of the comment causing issues, there should be no issues removing the comment and onlyif attribute searching for the comment.
Addresses: https://github.com/openshift/puppet-openshift_origin/issues/301
