### PR TITLE
Add yum repo names to avoid yum warning

### DIFF
--- a/manifests/yum_install_method.pp
+++ b/manifests/yum_install_method.pp
@@ -74,6 +74,7 @@ class openshift_origin::yum_install_method {
   }
 
   yumrepo { 'openshift-origin':
+    descr      => 'Openshift Origin',
     baseurl    => $repo_path_1,
     priority   => 1,
     gpgcheck   => 0,
@@ -82,6 +83,7 @@ class openshift_origin::yum_install_method {
   }
 
   yumrepo { 'openshift-deps':
+    descr      => 'Openshift Dependencies',
     baseurl    => $deps_path,
     priority   => 1,
     gpgcheck   => 0,


### PR DESCRIPTION
Yum generates warnings on each command invocation if a repository does not have the `name` attribute (`descr` in puppet) set. This PR fixes that issue for openshift-deps and openshift-origin.
