### PR TITLE
Remove mod_ssl default vhost

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -225,7 +225,11 @@ class openshift_origin::broker {
     hasrestart => true,
     require    => Package['openshift-origin-broker'],
   }
-
+  exec { 'Remove mod_ssl default vhost':
+    command => '/bin/sed -i \'/VirtualHost/,/VirtualHost/ d\' /etc/httpd/conf.d/ssl.conf',
+    onlyif  => '/bin/grep \'VirtualHost _default\' /etc/httpd/conf.d/ssl.conf',
+    require => Package['openshift-origin-broker'],
+  }
   if $::openshift_origin::install_login_shell {
     include openshift_origin::login_shell
   }


### PR DESCRIPTION
This is per oo-diagnostics warning which references the following
documentation suggesting removal of mod_ssl default vhost :

https://access.redhat.com/documentation/en-US/OpenShift_Enterprise/2/html/Deployment_Guide/Modifying_Broker_Proxy_Configuration.html
