### PR TITLE
Add openshift_origin::ose_supported_config

### DIFF
--- a/README_OSE.asciidoc
+++ b/README_OSE.asciidoc
@@ -1,0 +1,24 @@
+== Openshift Enterprise Specific notes
+
+If you wish to perform an Openshift Enterprise install you should set ose_version appropriately as this will
+assist in ensuring supported configurations.
+
+While this module will assist in providing supported configruations please refer to Openshift Enterprise
+Deployment Guide for current prerequisites and supported configuration details.
+
+=== Constraints imposed :
+  * Red Hat Enterprise Linux 6 version 6.5 or later
+  * Broker and Node roles are mutually exclusive
+  * Broker HA load balancing must be external to OSE nodes and therefore can not be configured via this module
+  * Avahi and Route53 DNS plugins are not supported
+  * ActiveMQ, if clustered, requires 2+ nodes
+  * MongoDB replicasets must 3+(2*n) nodes
+
+=== Yum repositories
+Configuring yum repositories via this module is not currently supported. Please ensure subscriptions and/or
+yum repositories are configured per the deployment guide. https://access.redhat.com/documentation/en-US/OpenShift_Enterprise/2/html/Deployment_Guide/Red_Hat_Subscription_Requirements.html
+
+=== TODO
+  * Use stored configs to push node dns changes from broker without sharing secrets to nodes
+  * Stored configs for districts
+  * Broker API key, rsync key?

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,21 @@
 # installations.
 #
 # === Parameters
+# [*ose_version*]
+#   If this is an Openshift Enterprise install this should be set according
+#   to the X.Y version, ie: '2.2'. Currently 2.2 is the only version for
+#   which a puppet module is supported by Red Hat. This sets various defaults
+#   to values appropriate for OSE installs and attempts to avoid unsupported
+#   configurations.
+#
+#   Default: undef
+#
+# [*ose_unsupported*]
+#   If you want to use OSE defaults but still allow an unsupported config, for instance
+#   in your test environment, set this to true to turn unsupported configs into warnings.
+#
+#   Default: false
+#
 # [*roles*]
 #   Choose from the following roles to be configured on this node.
 #     * broker        - Installs the broker and console.
@@ -691,6 +706,8 @@
 #    one node host to all the rest (or, if using the same image for all
 #    hosts, just keep the keys from the image).
 class openshift_origin (
+  $ose_version                          = undef,
+  $ose_unsupported                      = false,
   $roles                                = ['broker','node','msgserver','datastore','nameserver'],
   $install_method                       = 'yum',
   $parallel_deployment                  = false,
@@ -825,6 +842,11 @@ class openshift_origin (
   $manage_firewall                      = true,
 ){
   include openshift_origin::role
+
+  # Check for various unsupported OSE configs
+  if $ose_version != undef {
+    class { 'openshift_origin::ose_supported_config': }
+  }
 
   if $msgserver_cluster and ! $msgserver_cluster_members and ! $mcollective_cluster_members {
     fail('msgserver_cluster_members and mcollective_cluster_members parameters are required when msgserver_cluster is set')

--- a/manifests/ose_supported_config.pp
+++ b/manifests/ose_supported_config.pp
@@ -1,0 +1,81 @@
+# Copyright 2014 Red Hat, Inc., All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# == Class openshift_origin::ose_supported_config
+#
+# This class enforces or provides notices about unsupported configurations.
+#
+# TODO: write a custom function to avoid all the fail vs. notice logic
+#
+class openshift_origin::ose_supported_config {
+  if ($::operatingsystem != 'RedHat') or ($::operatingsystemmajrelease != '6') or
+      ($::operatingsystemrelease < '6.5') {
+    if $openshift_origin::ose_unsupported {
+      notice('Openshift Enterprise requires Red Hat Enterprise Linux Server 6 version 6.5 or later')
+    } else {
+      fail('Openshift Enterprise requires Red Hat Enterprise Linux Server 6 version 6.5 or later')
+    }
+  }
+  if member( $openshift_origin::node_frontend_plugins, 'apache-mod-rewrite' ) {
+      notice('Openshift Enterprise 2.2 has deprecated the apache-mod-rewrite frontend.')
+  }
+  if $::architecture != 'x86_64' {
+    if $openshift_origin::ose_unsupported {
+      notice('Openshift Enterprise is only supported on x86_64.')
+    } else {
+      fail('Openshift Enterprise is only supported on x86_64.')
+    }
+  }
+  if member( $openshift_origin::roles, 'node' ) and member( $openshift_origin::roles, 'broker' ) {
+    if $openshift_origin::ose_unsupported {
+      notice('Openshift Enterprise does not support co-location of node and broker')
+    } else {
+      fail('Openshift Enterprise does not support co-location of node and broker')
+    }
+  }
+  if member( $openshift_origin::roles, 'load_balancer' ) {
+    if $openshift_origin::ose_unsupported {
+      notice('Broker load balancing must be handled by external facilities')
+    } else {
+      fail('Broker load balancing must be handled by external facilities')
+    }
+  }
+  if $openshift_origin::broker_dns_plugin =~ /avahi|route53/  {
+    if $openshift_origin::ose_unsupported {
+      notice('Openshift Enterprise does not support avahi or route53 dns plugins')
+    } else {
+      fail('Openshift Enterprise does not support avahi or route53 dns plugins')
+    }
+  }
+  if $openshift_origin::msgserver_cluster {
+    if !(size($openshift_origin::msgserver_cluster_members) >= 2) {
+        if $openshift_origin::ose_unsupported {
+          notice('Openshift Enterprise requires at least 2 ActiveMQ nodes for clustered messaging')
+        } else {
+          fail('Openshift Enterprise requires at least 2 ActiveMQ nodes for clustered messaging')
+        }
+    }
+  }
+  if $openshift_origin::mongodb_replicasets {
+    if ( (size($openshift_origin::mongodb_replicasets_members) < 3) or
+          !((size($openshift_origin::mongodb_replicasets_members) % 2) == 1) ) {
+      if $openshift_origin::ose_unsupported {
+        notice('Openshift Enterprise requires replicasets have 3 or more members. It must also be an odd number of members.')
+      } else {
+        fail('Openshift Enterprise requires replicasets have 3 or more members. It must also be an odd number of members.')
+      }
+    }
+  }
+}
+

--- a/spec/classes/ose_supported_config_spec.rb
+++ b/spec/classes/ose_supported_config_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe 'openshift_origin' do
+  let :facts do {
+    :osfamily => 'RedHat',
+  } end
+
+  describe 'ose supported configs' do
+    let :facts do {
+      :osfamily => 'RedHat',
+      :operatingsystem => 'RedHat',
+      :operatingsystemmajrelease => '6',
+      :operatingsystemrelease => '6.5',
+      :architecture => 'x86_64',
+    } end
+    let :params do {
+      :ose_version  => 2.2,
+      :roles        => ['broker'],
+      # BIND / named config
+      # This is the key for updating the OpenShift BIND server
+      :bind_key                       => 'something',
+      # The domain under which applications should be created.
+      :domain                         => 'example.com',
+      # Apps would be named <app>-<namespace>.example.com
+      # This also creates hostnames for local components under our domain
+      :register_host_with_nameserver  => true,
+      # Forward requests for other domains (to Google by default)
+      :conf_nameserver_upstream_dns   => ['8.8.8.8', '8.8.4.4'],
+
+      # NTP Servers for OpenShift hosts to sync time
+      :ntp_servers => ['ntp.example.com iburst'],
+
+      # The FQDNs of the OpenShift component hosts
+      :broker_hostname     => 'broker.example.com',
+      :msgserver_hostname  => 'broker.example.com',
+      :node_hostname       => 'node.example.com',
+
+      # To enable installing the Jenkins cartridge:
+      :install_method    => 'yum',
+      :jenkins_repo_base => 'http://pkg.jenkins-ci.org/redhat',
+
+      # Cartridges to install on Node hosts
+      :install_cartridges         => ['php', 'mysql'],
+
+      #Enable development mode for more verbose logs
+      :development_mode           => true,
+
+      # apache-mod-rewrite is deprecated
+      :node_frontend_plugins   => ['apache-vhost'],
+
+      # clustered message servers need > 2 nodes
+      :msgserver_cluster  => true,
+      :msgserver_cluster_members  => ['1.1.1.1','2.2.2.2'],
+
+      # replicasets require 3 nodes
+      :mongodb_replicasets  => true,
+      :mongodb_replicasets_members  => ['a.example.com','b.example.com','c.example.com'],
+    } end
+    it { should compile.with_all_deps }
+  end
+end


### PR DESCRIPTION
This class checks for configurations that are not supported
by Openshift Enterprise. Includes basic spec tests for a good
configuration, but I need to add some unsupported test cases.
