### PR TITLE
Wherever we reference apache user add httpd package requirement

### DIFF
--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -127,7 +127,7 @@ class openshift_origin::broker {
       owner   => 'apache',
       group   => 'apache',
       mode    => '0640',
-      require => Class['openshift_origin::broker_console_dirs'],
+      require => [ Class['openshift_origin::broker_console_dirs'], Package['httpd'], ],
       notify  => Service['openshift-broker'],
     }
 
@@ -168,7 +168,7 @@ class openshift_origin::broker {
     owner   => 'apache',
     group   => 'apache',
     mode    => '0644',
-    require => Package['openshift-origin-broker'],
+    require => Package['openshift-origin-broker','httpd'],
     notify  => Service['openshift-broker'],
   }
 
@@ -179,7 +179,7 @@ class openshift_origin::broker {
       owner   => 'apache',
       group   => 'apache',
       mode    => '0644',
-      require => Package['openshift-origin-broker'],
+      require => Package['openshift-origin-broker','httpd'],
       notify  => Service['openshift-broker'],
     }
   }
@@ -214,7 +214,7 @@ class openshift_origin::broker {
     owner     => 'apache',
     group     => 'apache',
     mode      => '0644',
-    require   => Package['openshift-origin-broker'],
+    require   => Package['openshift-origin-broker','httpd'],
     subscribe => Exec['Broker gem dependencies'],
   }
 

--- a/manifests/console.pp
+++ b/manifests/console.pp
@@ -82,6 +82,7 @@ class openshift_origin::console {
     require => [
       Package['openshift-origin-console'],
       Class['openshift_origin::broker_console_dirs'],
+      Package['httpd'],
     ],
     notify  => Service['openshift-console'],
   }
@@ -96,6 +97,7 @@ class openshift_origin::console {
       require => [
         Package['openshift-origin-console'],
         Class['openshift_origin::broker_console_dirs'],
+        Package['httpd'],
       ],
       notify  => Service['openshift-console'],
     }
@@ -105,11 +107,11 @@ class openshift_origin::console {
   # by the following Exec has the appropriate permissions (otherwise
   # it is created as owned by root:root)
   file { '/var/www/openshift/console/Gemfile.lock':
-    ensure    => 'present',
-    owner     => 'apache',
-    group     => 'apache',
-    mode      => '0644',
-    require   => Package['openshift-origin-console'],
+    ensure  => 'present',
+    owner   => 'apache',
+    group   => 'apache',
+    mode    => '0644',
+    require => Package['openshift-origin-console','httpd'],
   }
 
   # SCL and Puppet don't play well together; the 'default' here
@@ -133,7 +135,7 @@ class openshift_origin::console {
     ${::openshift_origin::params::rm} -rf tmp/cache/* && \
     ${console_asset_rake_cmd} && \
     ${::openshift_origin::params::chown} -R apache:apache /var/www/openshift/console",
-    require     => Package['openshift-origin-console'],
+    require     => Package['openshift-origin-console','httpd'],
     subscribe   => [
       Package['openshift-origin-console'],
       File['/var/www/openshift/console/Gemfile.lock'],

--- a/manifests/mcollective_client.pp
+++ b/manifests/mcollective_client.pp
@@ -38,7 +38,7 @@ class openshift_origin::mcollective_client {
     owner   => 'apache',
     group   => 'apache',
     mode    => '0640',
-    require => Package['mcollective-client'],
+    require => Package['mcollective-client','httpd'],
   }
 
   file { 'mcollective log file':
@@ -47,6 +47,6 @@ class openshift_origin::mcollective_client {
     owner   => 'apache',
     group   => 'root',
     mode    => '0644',
-    require => Package['mcollective-client'],
+    require => Package['mcollective-client','httpd'],
   }
 }

--- a/manifests/plugins/auth/htpasswd.pp
+++ b/manifests/plugins/auth/htpasswd.pp
@@ -27,8 +27,8 @@ class openshift_origin::plugins::auth::htpasswd {
   }
 
   exec { 'Set first OpenShift user password':
-    command  => "/usr/bin/htpasswd -b /etc/openshift/htpasswd ${::openshift_origin::openshift_user1} ${::openshift_origin::openshift_password1}",
-    require  => [
+    command => "/usr/bin/htpasswd -b /etc/openshift/htpasswd ${::openshift_origin::openshift_user1} ${::openshift_origin::openshift_password1}",
+    require => [
       Package['httpd-tools'],
       File['htpasswd'],
     ],
@@ -54,7 +54,7 @@ class openshift_origin::plugins::auth::htpasswd {
     group   => 'apache',
     mode    => '0644',
     require => [
-      Package['rubygem-openshift-origin-auth-remote-user','openshift-origin-console'],
+      Package['rubygem-openshift-origin-auth-remote-user','openshift-origin-console','httpd'],
       File['Broker htpasswd config'],
     ],
     notify  => Service['openshift-console'],

--- a/manifests/plugins/auth/kerberos.pp
+++ b/manifests/plugins/auth/kerberos.pp
@@ -27,7 +27,7 @@ class openshift_origin::plugins::auth::kerberos {
     owner   => 'apache',
     group   => 'apache',
     mode    => '0644',
-    require => Package['rubygem-openshift-origin-auth-remote-user']
+    require => Package['rubygem-openshift-origin-auth-remote-user','httpd']
   }
 
   file {'broker kerbros.conf':
@@ -39,6 +39,7 @@ class openshift_origin::plugins::auth::kerberos {
     require => [
       Package['rubygem-openshift-origin-auth-remote-user'],
       Package['mod_auth_kerb'],
+      Package['httpd'],
       File['broker http keytab']
     ],
     notify  => Service['openshift-broker'],
@@ -54,6 +55,7 @@ class openshift_origin::plugins::auth::kerberos {
     require => [
       Package['rubygem-openshift-origin-auth-remote-user'],
       Package['mod_auth_kerb'],
+      Package['httpd'],
       File['broker http keytab']
     ],
     notify  => Service['openshift-console'],

--- a/manifests/plugins/dns/nsupdate.pp
+++ b/manifests/plugins/dns/nsupdate.pp
@@ -45,7 +45,7 @@ class openshift_origin::plugins::dns::nsupdate {
       owner   => 'apache',
       group   => 'apache',
       mode    => '0664',
-      require => Package['rubygem-openshift-origin-dns-nsupdate'],
+      require => Package['rubygem-openshift-origin-dns-nsupdate','httpd'],
     }
     file { 'plugin openshift-origin-dns-nsupdate.conf':
       path    => '/etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf',


### PR DESCRIPTION
This may be implicitly defined in many of the cases, but we'll go ahead
and make the requirement on httpd package explicit wherever we set
owner or group to 'apache'.

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1158271
