### PR TITLE
Refactor openshift_origin::register_dns to avoid using ensure_resource

### DIFF
--- a/manifests/register_dns.pp
+++ b/manifests/register_dns.pp
@@ -12,26 +12,24 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-define openshift_origin::register_dns($fqdn) {
+class openshift_origin::register_dns {
   if $::openshift_origin::register_host_with_nameserver {
     if $fqdn != 'localhost' {
-      ensure_resource( 'package','bind-utils', {
+      package { 'bind-utils' :
           ensure  => present,
           require => Class['openshift_origin::install_method'],
-        }
-      )
+      }
       $key_algorithm=pick($::openshift_origin::dns_infrastructure_key_algorithm,
         $::openshift_origin::bind_key_algorithm)
       $key_secret=pick($::openshift_origin::dns_infrastructure_key,
         $::openshift_origin::bind_key)
       $key_argument="${key_algorithm}:${::openshift_origin::domain}:${key_secret}"
 
-      ensure_resource( 'exec', "Register ${fqdn}", {
-          command   => template('openshift_origin/register_dns.erb'),
-          provider  => 'shell',
-          require   => Package['bind-utils'],
-        }
-      )
+      exec { "Register ${fqdn}" :
+        command   => template('openshift_origin/register_dns.erb'),
+        provider  => 'shell',
+        require   => Package['bind-utils'],
+      }
     }
   }
 }

--- a/manifests/role/broker.pp
+++ b/manifests/role/broker.pp
@@ -16,9 +16,5 @@ class openshift_origin::role::broker inherits openshift_origin::role {
   include openshift_origin::client_tools
   include openshift_origin::broker
   include openshift_origin::console
-
-  openshift_origin::register_dns{ 'register broker dns':
-    fqdn    => $::openshift_origin::broker_hostname,
-    require => Class['openshift_origin::client_tools','openshift_origin::broker','openshift_origin::console']
-  }
+  include openshift_origin::register_dns
 }

--- a/manifests/role/datastore.pp
+++ b/manifests/role/datastore.pp
@@ -14,9 +14,5 @@
 #
 class openshift_origin::role::datastore inherits openshift_origin::role {
   include openshift_origin::datastore
-
-  openshift_origin::register_dns{ 'register datastore dns':
-    fqdn    => $::openshift_origin::datastore_hostname,
-    require => Class['openshift_origin::datastore'],
-  }
+  include openshift_origin::register_dns
 }

--- a/manifests/role/load_balancer.pp
+++ b/manifests/role/load_balancer.pp
@@ -1,8 +1,4 @@
 class openshift_origin::role::load_balancer inherits openshift_origin::role {
   include openshift_origin::load_balancer
-
-  openshift_origin::register_dns{ 'register virtual broker dns':
-    fqdn    => $::openshift_origin::broker_virtual_hostname,
-    require => Class['openshift_origin::load_balancer'],
-  }
+  include openshift_origin::register_dns
 }

--- a/manifests/role/msgserver.pp
+++ b/manifests/role/msgserver.pp
@@ -14,9 +14,5 @@
 #
 class openshift_origin::role::msgserver inherits openshift_origin::role {
   include openshift_origin::msgserver
-
-  openshift_origin::register_dns{ 'register msgserver dns':
-    fqdn    => $::openshift_origin::msgserver_hostname,
-    require => Class['openshift_origin::msgserver'],
-  }
+  include openshift_origin::register_dns
 }

--- a/manifests/role/nameserver.pp
+++ b/manifests/role/nameserver.pp
@@ -14,9 +14,4 @@
 #
 class openshift_origin::role::nameserver inherits openshift_origin::role {
   include openshift_origin::nameserver
-
-  openshift_origin::register_dns{ 'register nameserver dns':
-    fqdn    => $::openshift_origin::nameserver_hostname,
-    require => Class['openshift_origin::nameserver']
-  }
 }

--- a/manifests/role/node.pp
+++ b/manifests/role/node.pp
@@ -14,9 +14,5 @@
 #
 class openshift_origin::role::node inherits openshift_origin::role {
   include openshift_origin::node
-
-  openshift_origin::register_dns{ 'register node dns':
-    fqdn    => $::openshift_origin::node_hostname,
-    require => Class['openshift_origin::node'],
-  }
+  include openshift_origin::register_dns
 }

--- a/templates/register_dns.erb
+++ b/templates/register_dns.erb
@@ -1,9 +1,13 @@
-(
+  (
+<% scope.lookupvar('::openshift_origin::roles').each do |role|
+  role_hostname = scope.lookupvar("openshift_origin::#{role}_hostname")
+%>
   echo server <%= scope.lookupvar('::openshift_origin::nameserver_ip_addr') %>
-  echo update delete <%= scope.lookupvar('fqdn') %> A
-  echo update add <%= scope.lookupvar('fqdn') %> 180 A <%= scope.lookupvar('::openshift_origin::node_ip_addr') %>
+  echo update delete <%= role_hostname %> A
+  echo update add <%= role_hostname %> 180 A <%= scope.lookupvar('::openshift_origin::node_ip_addr') %>
+<% end %>
   echo send
-) | nsupdate -y <%= @key_argument %>
+)| nsupdate -y <%= @key_argument %>
 <% if scope.lookupvar('::openshift_origin::load_balancer_master') and scope.lookupvar('::openshift_origin::broker_virtual_ip_address')%>
 (
   echo server <%= scope.lookupvar('::openshift_origin::nameserver_ip_addr') %>


### PR DESCRIPTION
We've discovered that ensure_resource has a bug[1] that leads to the command parameter being ignored. This seems to be addressed by upgrading to Puppet 3.3.0 or later, however we don't want to force users to do that. Additionally, register_dns had a few issues, mostly centered around the fact that we were passing in a 'fqdn' that really wasn't a FQDN but instead strings like 'register $role dns' which would then call an exec titled 'Register $fqdn'. Hopefully this simplifies things a bit.
1. https://tickets.puppetlabs.com/browse/MODULES-832
