### PR TITLE
Jenkins cartridge depends on wget.

### DIFF
--- a/manifests/cartridges/jenkins.pp
+++ b/manifests/cartridges/jenkins.pp
@@ -13,7 +13,7 @@
 #  limitations under the License.
 #
 class openshift_origin::cartridges::jenkins {
-  package { 'jenkins':
+  package { ['jenkins','wget'] :
     ensure  => present,
     require => Class['openshift_origin::install_method'],
   }


### PR DESCRIPTION
I'll investigate if we should make wget a dependency of openshift-origin-cartridge-jenkins. I suspect it should so it's also installed on hosts that aren't puppet managed.
