### PR TITLE
fixes for register_dns

### DIFF
--- a/manifests/register_dns.pp
+++ b/manifests/register_dns.pp
@@ -23,7 +23,9 @@ class openshift_origin::register_dns {
         $::openshift_origin::bind_key_algorithm)
       $key_secret=pick($::openshift_origin::dns_infrastructure_key,
         $::openshift_origin::bind_key)
-      $key_argument="${key_algorithm}:${::openshift_origin::domain}:${key_secret}"
+      $key_domain=pick($::openshift_origin::dns_infrastructure_zone,
+        $::openshift_origin::domain)
+      $key_argument="${key_algorithm}:${key_domain}:${key_secret}"
 
       exec { "Register ${::fqdn}" :
         command   => template('openshift_origin/register_dns.erb'),

--- a/templates/register_dns.erb
+++ b/templates/register_dns.erb
@@ -1,17 +1,20 @@
   (
   echo server <%= scope.lookupvar('::openshift_origin::nameserver_ip_addr') %>
-<% role_hostnames = Array.new %>
+<% role_hostnames = Array.new -%>
 <% scope.lookupvar('::openshift_origin::roles').each do |role|
-  role_hostnames << scope.lookupvar("::openshift_origin::#{role}_hostname") -%>
+  role_hostname = scope.lookupvar("::openshift_origin::#{role}_hostname")
+  if role_hostname.gsub(/^[^.]*./, '') == @key_domain
+    role_hostnames << role_hostname
+  end -%>
 <% end -%>
-<% role_hostnames.uniq.each do |role_hostname| %>
+<% role_hostnames.uniq.each do |role_hostname| -%>
   echo update delete <%= role_hostname %> A
   echo update add <%= role_hostname %> 180 A <%= scope.lookupvar('::openshift_origin::node_ip_addr') %>
-<% end %>
-<% if scope.lookupvar('::openshift_origin::load_balancer_master') and scope.lookupvar('::openshift_origin::broker_virtual_ip_address') %>
+<% end -%>
+<% if scope.lookupvar('::openshift_origin::load_balancer_master') and scope.lookupvar('::openshift_origin::broker_virtual_ip_address') and scope.lookupvar('::openshift_origin::broker_virtual_hostname').gsub(/^[^.]*./, '') == @key_domain -%>
 (
   echo update delete <%= scope.lookupvar('::openshift_origin::broker_virtual_hostname') %> A
   echo update add <%= scope.lookupvar('::openshift_origin::broker_virtual_hostname') %> 180 A <%= scope.lookupvar('::openshift_origin::broker_virtual_ip_address') %>
-<% end-%>
+<% end -%>
   echo send
 ) | nsupdate -y <%= @key_argument %>


### PR DESCRIPTION
- do not attempt to update dns records for hosts that are not a member
  of the host domain ($dns_infrastructure_zone if set, otherwise
  $domain)
- fix bug where nsupdate was being run against the $domain variable
  if $dns_infrastructure_zone is set.
- remove extra spaces output from register_dns.erb template
