### PR TITLE
Retry 6 times with 30 second sleep time when adding replicaset members

### DIFF
--- a/manifests/datastore.pp
+++ b/manifests/datastore.pp
@@ -127,8 +127,8 @@ class openshift_origin::datastore {
         path      => ['/bin/', '/usr/bin/', '/usr/sbin/'],
         command   => "mongo admin --host ${openshift_origin::mongodb_replica_primary_ip_addr} -u ${openshift_origin::mongodb_admin_user} -p ${openshift_origin::mongodb_admin_password} --quiet --eval \"printjson(rs.add(\'${::ipaddress}:${port}\'))\"",
         unless    => "mongo admin --host ${openshift_origin::mongodb_replica_primary_ip_addr} -u ${openshift_origin::mongodb_admin_user} -p ${openshift_origin::mongodb_admin_password} --quiet --eval \"printjson(rs.status())\" | grep '\"name\" : \"${::ipaddress}:${port}\"'",
-        tries     => 3,
-        try_sleep => 5,
+        tries     => 6,
+        try_sleep => 30,
         require   => [
           Service['mongod'],
           Exec['keyfile-mongo-conf', 'replset-mongo-conf']


### PR DESCRIPTION
If someone attempts to deploy all three replicaset members at once tolerate up to three minutes for primary
replicaset initialization. Any longer than that just handle it manually.
