### PR TITLE
Create /etc/openshift/development when development_mode = true

### DIFF
--- a/files/development
+++ b/files/development
@@ -1,0 +1,1 @@
+Created by puppet

--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -226,6 +226,13 @@ class openshift_origin::broker {
       notify  => Service['openshift-broker'],
     }
   }
+  file { '/etc/openshift/development':
+    source  => 'puppet:///openshift_origin/development',
+    ensure  => $::openshift_origin::development_mode ? {
+        true    => present,
+        default => absent,
+      }
+  }
 
   # SCL and Puppet don't play well together; the 'default' here
   # circumvents the use of the `scl enable ruby193` mechanism
@@ -267,6 +274,7 @@ class openshift_origin::broker {
     hasstatus  => true,
     hasrestart => true,
     require    => Package['openshift-origin-broker'],
+    subscribe  => File['/etc/openshift/development'],
   }
   exec { 'Remove mod_ssl default vhost':
     command => '/bin/sed -i \'/VirtualHost/,/VirtualHost/ d\' /etc/httpd/conf.d/ssl.conf',

--- a/manifests/console.pp
+++ b/manifests/console.pp
@@ -162,5 +162,6 @@ class openshift_origin::console {
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
+    subscribe  => File['/etc/openshift/development'],
   }
 }


### PR DESCRIPTION
This file is necessary to trigger console and broker applications to run inside a development, versus
production, rails environment. This file also triggers additional logging for gear placement and other
plugins.
