### PR TITLE
Issue350 - Don't create quickstarts on OSE installs

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -931,6 +931,14 @@ This parameter is only used when _ose_version_ is set.
 
 Default: false
 
+=== quickstarts_json
+JSON content to be deployed into /etc/openshift/quickstarts.json
+
+Default: undef, which on Origin will deploy the contents
+of templates/broker/quickstarts.json.erb
+
+OSE Default: undef and will not deploy any quickstarts
+
 == Manual Tasks
 
 This script attempts to automate as many tasks as it reasonably can.

--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -184,10 +184,18 @@ class openshift_origin::broker {
     }
   }
 
+  if $::openshift_origin::quickstarts_json {
+    $quickstart_content = $::openshift_origin::quickstarts_json
+  } elsif $::openshift_origin::ose_version == undef {
+    $quickstart_content = template('openshift_origin/broker/quickstarts.json.erb')
+  } else {
+    $quickstart_content = ''
+  }
+
   file { 'quickstarts':
     ensure  => present,
     path    => '/etc/openshift/quickstarts.json',
-    content => template('openshift_origin/broker/quickstarts.json.erb'),
+    content => $quickstart_content,
     owner   => 'root',
     group   => 'root',
     mode    => '0644',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -720,6 +720,14 @@
 #
 #   Default: undef
 #
+# [*quickstarts_json*]
+#   JSON content to be deployed into /etc/openshift/quickstarts.json
+#
+#   Default: undef, which on Origin will deploy the contents
+#   of templates/broker/quickstarts.json.erb
+#
+#   OSE Default: undef and will not deploy any quickstarts
+#
 # == Manual Tasks
 #
 # This script attempts to automate as many tasks as it reasonably can.


### PR DESCRIPTION
Quickstarts often use cartridges that may not be installed or activated so lets
not install the quickstarts on OSE
