### PR TITLE
Clarify broker_krb_service_name documentation

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -673,7 +673,10 @@ Options:
 Default: htpasswd
 
 === broker_krb_service_name
-The KrbServiceName value for mod_auth_kerb configuration
+The KrbServiceName value for mod_auth_kerb configuration. This value will be
+prefixed with 'HTTP/' to create the krb5 service principal.
+
+Default: hostname
 
 === broker_krb_auth_realms
 The KrbAuthRealms value for mod_auth_kerb configuration

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -477,7 +477,9 @@
 #   Default: htpasswd
 #
 # [*broker_krb_service_name*]
-#   The KrbServiceName value for mod_auth_kerb configuration
+#   The KrbServiceName value for mod_auth_kerb configuration. This value will be
+#   prefixed with 'HTTP/' to create the krb5 service principal value.
+# Default: $hostname
 #
 # [*broker_krb_auth_realms*]
 # The KrbAuthRealms value for mod_auth_kerb configuration


### PR DESCRIPTION
broker_krb_service_name is prefxied with 'HTTP/' string and used by mod_auth_krb
where as bind_krb_principal is expected to be the full principal name. We could
normalize those two but for now just document the proper use.
