### PR TITLE
Allow client certs to be read by apache

### DIFF
--- a/manifests/mcollective_client.pp
+++ b/manifests/mcollective_client.pp
@@ -34,6 +34,46 @@ class openshift_origin::mcollective_client {
   if ($::openshift_origin::msgserver_tls_enabled == 'enabled' or $::openshift_origin::msgserver_tls_enabled == 'strict') {
     if ($::openshift_origin::msgserver_tls_ca != '') and ($::openshift_origin::msgserver_tls_key != '') and ($::openshift_origin::msgserver_tls_cert != '') {
       $tls_certs_provided = true
+
+      file { 'mcollective client cert directory':
+        ensure  => 'directory',
+        path    => "${::openshift_origin::params::ruby_scl_path_prefix}/etc/mcollective/certs/",
+        owner   => 'apache',
+        group   => 'apache',
+        mode    => '0750',
+        require => Package['mcollective-client'],
+      }
+
+      file { 'mcollective client tls ca':
+        ensure  => 'present',
+        path    => "${::openshift_origin::params::ruby_scl_path_prefix}/etc/mcollective/certs/ca.pem",
+        owner   => 'apache',
+        group   => 'apache',
+        mode    => '0640',
+        source  => $::openshift_origin::msgserver_tls_ca,
+        require => Package['mcollective-client'],
+      }
+
+      file { 'mcollective client tls cert':
+        ensure  => 'present',
+        path    => "${::openshift_origin::params::ruby_scl_path_prefix}/etc/mcollective/certs/cert.pem",
+        owner   => 'apache',
+        group   => 'apache',
+        mode    => '0640',
+        source  => $::openshift_origin::msgserver_tls_cert,
+        require => Package['mcollective-client'],
+      }
+      
+      file { 'mcollective client tls key':
+        ensure  => 'present',
+        path    => "${::openshift_origin::params::ruby_scl_path_prefix}/etc/mcollective/certs/key.pem",
+        owner   => 'apache',
+        group   => 'apache',
+        mode    => '0640',
+        source  => $::openshift_origin::msgserver_tls_key,
+        require => Package['mcollective-client'],
+      }
+      
     } else { $tls_certs_provided = false }
   }
 

--- a/templates/mcollective/mcollective-client.cfg.erb
+++ b/templates/mcollective/mcollective-client.cfg.erb
@@ -22,9 +22,9 @@ plugin.activemq.pool.<%= index + 1%>.password = <%= scope.lookupvar('::openshift
   <% if (scope.lookupvar('::openshift_origin::msgserver_tls_enabled') == 'enabled' and @tls_certs_provided == true) or scope.lookupvar('::openshift_origin::msgserver_tls_enabled') == 'strict' -%>
   plugin.activemq.pool.<%= index + 1%>.port = 61614
   plugin.activemq.pool.<%= index + 1%>.ssl = true
-  plugin.activemq.pool.<%= index + 1%>.ssl.ca = <%= scope.lookupvar('::openshift_origin::msgserver_tls_ca') %>
-  plugin.activemq.pool.<%= index + 1%>.ssl.key = <%= scope.lookupvar('::openshift_origin::msgserver_tls_key') %>
-  plugin.activemq.pool.<%= index + 1%>.ssl.cert = <%= scope.lookupvar('::openshift_origin::msgserver_tls_cert') %>
+  plugin.activemq.pool.<%= index + 1%>.ssl.ca = <%= scope.lookupvar('::openshift_origin::params::ruby_scl_path_prefix') %>/certs/ca.pem
+  plugin.activemq.pool.<%= index + 1%>.ssl.key = <%= scope.lookupvar('::openshift_origin::params::ruby_scl_path_prefix') %>/certs/key.pem
+  plugin.activemq.pool.<%= index + 1%>.ssl.cert = <%= scope.lookupvar('::openshift_origin::params::ruby_scl_path_prefix') %>/certs/cert.pem
   <% else %>
   plugin.activemq.pool.<%= index + 1%>.port = 61613
   <% end %>
@@ -39,9 +39,9 @@ plugin.activemq.pool.1.password = <%= scope.lookupvar('::openshift_origin::mcoll
   <% if (scope.lookupvar('::openshift_origin::msgserver_tls_enabled') == 'enabled' and @tls_certs_provided == true) or scope.lookupvar('::openshift_origin::msgserver_tls_enabled') == 'strict' -%>
   plugin.activemq.pool.1.port = 61614
   plugin.activemq.pool.1.ssl = true
-  plugin.activemq.pool.1.ssl.ca = <%= scope.lookupvar('::openshift_origin::msgserver_tls_ca') %>
-  plugin.activemq.pool.1.ssl.key = <%= scope.lookupvar('::openshift_origin::msgserver_tls_key') %>
-  plugin.activemq.pool.1.ssl.cert = <%= scope.lookupvar('::openshift_origin::msgserver_tls_cert') %>
+  plugin.activemq.pool.1.ssl.ca = <%= scope.lookupvar('::openshift_origin::params::ruby_scl_path_prefix') %>/certs/ca.pem
+  plugin.activemq.pool.1.ssl.key = <%= scope.lookupvar('::openshift_origin::params::ruby_scl_path_prefix') %>/certs/key.pem
+  plugin.activemq.pool.1.ssl.cert = <%= scope.lookupvar('::openshift_origin::params::ruby_scl_path_prefix') %>/certs/cert.pem
   <% else -%>  
   plugin.activemq.pool.1.port = 61613
   <% end -%>


### PR DESCRIPTION
Although oo-mco ping will succeed, application creation will fail because apache cannot read the certs. Moving them to an apache readable location works around this issue. 
