### PR TITLE
Clean up to avoid unnecessary notices and service restarts

### DIFF
--- a/manifests/cartridges/jenkins.pp
+++ b/manifests/cartridges/jenkins.pp
@@ -18,6 +18,8 @@ class openshift_origin::cartridges::jenkins {
     require => Class['openshift_origin::install_method'],
   }
   exec { '/usr/bin/yum versionlock jenkins':
-    require => Package['jenkins', 'yum-plugin-versionlock'],
+    require     => Package['jenkins', 'yum-plugin-versionlock'],
+    subscribe   => Package['jenkins'],
+    refreshonly => true,
   }
 }

--- a/manifests/console.pp
+++ b/manifests/console.pp
@@ -112,11 +112,12 @@ class openshift_origin::console {
   # by the following Exec has the appropriate permissions (otherwise
   # it is created as owned by root:root)
   file { '/var/www/openshift/console/Gemfile.lock':
-    ensure  => 'present',
-    owner   => 'apache',
-    group   => 'apache',
-    mode    => '0644',
-    require => Package['openshift-origin-console','httpd'],
+    ensure                  => 'present',
+    owner                   => 'apache',
+    group                   => 'apache',
+    mode                    => '0644',
+    selinux_ignore_defaults => true,
+    require                 => Package['openshift-origin-console','httpd'],
   }
 
   # SCL and Puppet don't play well together; the 'default' here
@@ -143,10 +144,11 @@ class openshift_origin::console {
   }
 
   exec { 'restorecon console dir':
-    command  => 'restorecon -R /var/www/openshift/console',
-    provider => 'shell',
-    require  => Package['openshift-origin-console'],
-    notify   => Service['openshift-console'],
+    command     => 'restorecon -R /var/www/openshift/console',
+    provider    => 'shell',
+    require     => Package['openshift-origin-console'],
+    notify      => Service['openshift-console'],
+    refreshonly => true,
   }
 
   service { 'openshift-console':

--- a/manifests/selbooleans/broker_console.pp
+++ b/manifests/selbooleans/broker_console.pp
@@ -14,9 +14,11 @@ class openshift_origin::selbooleans::broker_console {
     persistent => true,
   }
   exec { 'Broker / Console restorecon commands':
-    command => template('openshift_origin/selinux/broker_console_restorecons.erb'),
-    require => Package['openshift-origin-broker','openshift-origin-console'],
-    notify  => Service['openshift-broker'],
-    timeout => 1800,
+    command     => template('openshift_origin/selinux/broker_console_restorecons.erb'),
+    subscribe   => Package['openshift-origin-broker','openshift-origin-console'],
+    require     => Package['openshift-origin-broker','openshift-origin-console'],
+    notify      => Service['openshift-broker'],
+    timeout     => 1800,
+    refreshonly => true,
   }
 }

--- a/manifests/selbooleans/node.pp
+++ b/manifests/selbooleans/node.pp
@@ -9,11 +9,16 @@ class openshift_origin::selbooleans::node {
     persistent => true,
   }
   exec { 'node restorecon commands':
-    command => 'restorecon -rv /var/run; restorecon -rv /var/lib/openshift /etc/openshift/node.conf',
-    timeout => 1800,
-    require => [
+    command     => 'restorecon -rv /var/run; restorecon -rv /var/lib/openshift /etc/openshift/node.conf',
+    timeout     => 1800,
+    refreshonly => true,
+    subscribe   => [
       Package['rubygem-openshift-origin-node'],
       File['openshift node config'],
-    ]
+    ],
+    require     => [
+      Package['rubygem-openshift-origin-node'],
+      File['openshift node config'],
+    ],
   }
 }


### PR DESCRIPTION
Here are some tweaks I've been using for the past few months in my own fork which would avoid the notices being generated while using foreman, keeping the host being marked as active as it's not receiving the exit 0. Also without these changes, the broker service would be restarted every 30 minutes.

selinux_ignore_defaults is required to avoid the back and forth switching of label type.
