### PR TITLE
BZ1170859 - Only install recommended deps for installed cartridges

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -981,7 +981,7 @@ class openshift_origin (
   }
 
   $cartridge_deps_to_install = $install_cartridges_recommended_deps ? {
-    undef   => $cartridge_deps_to_install_default,
+    undef   => intersection($cartridge_deps_to_install_default, $cartridges_to_install),
     default => $install_cartridges_recommended_deps,
   }
 


### PR DESCRIPTION
Unless the user specifies recommended dependencies only install dependencies
that match their installed cartridges. This still takes into account the
differences between OSE and Origin.
