### PR TITLE
Remove extraneous package requirements from node role

### DIFF
--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -39,14 +39,8 @@ class openshift_origin::node {
     ['rubygem-openshift-origin-node',
       "${::openshift_origin::params::ruby_scl_prefix}rubygem-passenger-native",
       'openshift-origin-node-util',
-      'policycoreutils-python',
       'openshift-origin-msg-node-mcollective',
-      'git',
-      'make',
-      'oddjob',
-      'dbus',
       'mlocate',
-      'libcgroup',
     ]:
     ensure  => present,
     require => Class['openshift_origin::install_method'],
@@ -214,8 +208,6 @@ class openshift_origin::node {
       Package['rubygem-openshift-origin-node'],
       Package['openshift-origin-node-util'],
       Package['mcollective'],
-      Package['oddjob'],
-      Package['dbus'],
     ],
   }
   Service['messagebus'] -> Service['oddjobd']
@@ -247,7 +239,7 @@ class openshift_origin::node {
   service { ['cgconfig', 'cgred']:
     ensure  => running,
     enable  => true,
-    require => [Package['libcgroup'], Augeas['openshift cgconfig']],
+    require => [Package['rubygem-openshift-origin-node'], Augeas['openshift cgconfig']],
   }
 
   service { ['openshift-gears']:


### PR DESCRIPTION
Resolves #332 

vim-enhanced and screen are completely unnecessary. The rest are all dependencies of other core packages we're managing and have been for as long as I can tell. 
