### PR TITLE
Add oo-admin-yum-validator for OSE installs

### DIFF
--- a/README_OSE.asciidoc
+++ b/README_OSE.asciidoc
@@ -17,9 +17,18 @@ Deployment Guide for current prerequisites and supported configuration details.
   * 10gen-mms-agent and phpmyadmin cartridges are not included in Openshift Enterprise and therefore have been
     removed from the list of default cartridges
 
+=== oo-admin-yum-validator
+If ose_version is set then oo-admin-yum-validator with the ---fixall flag will be
+run prior to installing OSE packages. Once oo-admin-yum-validator has run
+successfully puppet will not run it again. If you modify your yum configuration
+after oo-admin-yum-validator has been executed you should you should re-run
+oo-admin-yum-validator to ensure proper repo priorities and package exclusions.
+
 === Yum repositories
-Configuring yum repositories via this module is not currently supported. Please ensure subscriptions and/or
-yum repositories are configured per the deployment guide. https://access.redhat.com/documentation/en-US/OpenShift_Enterprise/2/html/Deployment_Guide/Red_Hat_Subscription_Requirements.html
+Configuring yum repositories via this module is not currently supported. Please
+ensure subscriptions and/or yum repositories are configured per the deployment
+guide.
+https://access.redhat.com/documentation/en-US/OpenShift_Enterprise/2/html/Deployment_Guide/Red_Hat_Subscription_Requirements.html
 
 === TODO
   * Use stored configs to push node dns changes from broker without sharing secrets to nodes

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -908,8 +908,6 @@ class openshift_origin (
   $install_cartridges_optional_deps     = undef,
   $manage_firewall                      = true,
 ) inherits openshift_origin::params {
-  include openshift_origin::role
-
   $default_host_domain = $dns_infrastructure_zone ? {
     ''        => $domain,
     default   => $dns_infrastructure_zone,

--- a/manifests/install_method.pp
+++ b/manifests/install_method.pp
@@ -23,7 +23,13 @@ class openshift_origin::install_method {
       class { 'openshift_origin::yum_install_method':
         stage => 'first',
       }
+      Class['Openshift_origin::Yum_install_method'] ->
+      Class['Openshift_origin::Oo_admin_yum_validator']
     }
     default: {}
   }
+  class { 'openshift_origin::oo_admin_yum_validator':
+    stage => 'first',
+  }
 }
+

--- a/manifests/oo_admin_yum_validator.pp
+++ b/manifests/oo_admin_yum_validator.pp
@@ -1,0 +1,39 @@
+# Runs oo-admin-yum-validator ensuring OSE repos have higher priorities and
+# a few key package exclusions in order to assist in ensuring a supportable
+# install
+#
+# oo-admin-yum-validator has the following roles node, broker, client, node-eap,
+# node-fuse, node-amq which we have to translate puppet's concept of roles into,
+# broker is trivial, node roles get dicey because we have to examine the
+# cartridges being installed and add aditional oo-admin-yum-validator roles
+# based on those
+class openshift_origin::oo_admin_yum_validator {
+  if $::openshift_origin::ose_version {
+    package{ 'openshift-enterprise-yum-validator': }
+
+    $carts = $::openshift_origin::cartridges_to_install
+    $roles = $::openshift_origin::roles
+    if member($carts, 'amq') and member($roles, 'node') { $role_amq = 'node-amq' } else { $role_amq = '' }
+    if member($carts, 'jbosseap') and member($roles, 'node') { $role_eap = 'node-eap' } else { $role_eap = '' }
+    if member($carts, 'fuse') and member($roles, 'node') { $role_fuse = 'node-fuse' } else { $role_fuse = '' }
+    if member($roles, 'node') { $role_node = 'node' } else { $role_node = '' }
+    if member($roles, 'broker') { $role_broker = 'broker -r client' } else { $role_broker = '' }
+    $role_list = [$role_node, $role_amq, $role_eap, $role_fuse, $role_broker]
+    $role_string = join( prefix( delete( $role_list, '' ), ' -r ' ), '' )
+
+    # oo-admin-yum-validator -a returns 1 if it made changes and 0 if no changes
+    # so use a wrapper to fix everything then call it again to check for issues
+    file { '/usr/local/bin/puppet-oo-admin-yum-validator':
+      mode    => '0755',
+      content => template('openshift_origin/puppet-oo-admin-yum-validator.erb'),
+      notify  => Exec['Yum validator fix-all'],
+    }
+    # refresh only so we only run this when roles change
+    exec { 'Yum validator fix-all':
+      command     => '/usr/local/bin/puppet-oo-admin-yum-validator',
+      require     => [  Package['openshift-enterprise-yum-validator'],
+                        File['/usr/local/bin/puppet-oo-admin-yum-validator'], ],
+      refreshonly => true,
+    }
+  }
+}

--- a/manifests/role.pp
+++ b/manifests/role.pp
@@ -14,7 +14,7 @@
 #  limitations under the License.
 #
 class openshift_origin::role {
-  include openshift_origin::install_method
+  require openshift_origin::install_method
   require openshift_origin::firewall::ssh
 
   if ( $::openshift_origin::configure_ntp ) {

--- a/templates/puppet-oo-admin-yum-validator.erb
+++ b/templates/puppet-oo-admin-yum-validator.erb
@@ -1,0 +1,15 @@
+#!/bin/bash
+# oo-admin-yum-validator exits with 1 when it makes changes
+# so run it once with fix-all, then run it in reporting mode
+# to see if there are problems, if not write out a success marker
+# so puppet doesn't run this again
+ooayv=$( /usr/bin/oo-admin-yum-validator -o <%= scope.lookupvar('::openshift_origin::ose_version') %> -a <%= @role_string %> )
+ooayv=$( /usr/bin/oo-admin-yum-validator -o <%= scope.lookupvar('::openshift_origin::ose_version') %> <%= @role_string %> )
+if [ $? -eq 0 ]
+then
+   touch /etc/yum-validator/.oo_admin_yum_validator_success
+   exit 0
+else
+   exit 1
+fi
+


### PR DESCRIPTION
This utility ensures proper yum repo prioties and sets up excludes for certain
packages. This utility is expected to be run after all appopriate yum repos have
been created and before installing OSE components.

More details on this tool:
https://github.com/openshift/openshift-extras/tree/master/admin/yum-validator