### PR TITLE
add conf_ha_dns_prefix and conf_ha_dns_suffix

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -623,6 +623,14 @@ value must be the same on all broker nodes.
 
 Default: undef
 
+=== conf_ha_dns_prefix
+=== conf_ha_dns_suffix
+Prefix/Suffix used for Highly Available application URL
+http://${HA_DNS_PREFIX}${APP_NAME}-${DOMAIN_NAME}${HA_DNS_SUFFIX}.${CLOUD_DOMAIN}
+
+Default prefix: 'ha-'
+Default suffix: ''
+
 === conf_valid_gear_sizes
 List of all gear sizes this will be used in this OpenShift installation.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -461,6 +461,13 @@
 # 
 #  Default: 1
 #
+# [*conf_ha_dns_prefix*]
+# [*conf_ha_dns_suffix*]
+#   Prefix/Suffix used for Highly Available application URL
+#   http://${HA_DNS_PREFIX}${APP_NAME}-${DOMAIN_NAME}${HA_DNS_SUFFIX}.${CLOUD_DOMAIN}
+#   Default prefix: 'ha-'
+#   Default suffix: ''
+#
 # [*conf_valid_gear_sizes*]
 #   List of all gear sizes this will be used in this OpenShift installation.
 #   Default: ['small']
@@ -891,6 +898,8 @@ class openshift_origin (
   $openshift_password1                  = 'changeme',
   $conf_broker_auth_salt                = inline_template('<%= require "securerandom"; SecureRandom.base64 %>'),
   $conf_broker_auth_private_key         = undef,
+  $conf_ha_dns_prefix                   = 'ha-',
+  $conf_ha_dns_suffix                   = '',
   $conf_broker_session_secret           = undef,
   $conf_broker_default_region_name      = '',
   $conf_broker_allow_region_selection   = false,

--- a/templates/broker/broker.conf.erb
+++ b/templates/broker/broker.conf.erb
@@ -156,8 +156,8 @@ ROUTER_HOSTNAME="www.example.com"
 
 # Prefix/Suffix used for Highly Available application URL
 # http://${HA_DNS_PREFIX}${APP_NAME}-${DOMAIN_NAME}${HA_DNS_SUFFIX}.${CLOUD_DOMAIN}
-HA_DNS_PREFIX="ha-"
-HA_DNS_SUFFIX=""
+HA_DNS_PREFIX="<%= scope.lookupvar('::openshift_origin::conf_ha_dns_prefix') %>"
+HA_DNS_SUFFIX="<%= scope.lookupvar('::openshift_origin::conf_ha_dns_suffix') %>"
 
 # Determine whether or not multiple HA proxy gears for a given application can be spun up on the same node
 ALLOW_MULTIPLE_HAPROXY_ON_NODE=<%= scope.lookupvar('::openshift_origin::conf_broker_multi_haproxy_per_node') %>


### PR DESCRIPTION
Allow customization for HA_DNS_PREFIX and HA_DNS_SUFFIX.

This PR is a subpart of https://github.com/openshift/puppet-openshift_origin/pull/371.
I can close https://github.com/openshift/puppet-openshift_origin/pull/371 if https://github.com/openshift/puppet-openshift_origin/pull/312 is merged