### PR TITLE
Add syslog configuration

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -901,6 +901,7 @@ Default: false
 
 === syslog_enabled
 Direct logs to syslog rather than log files.
+Get more details on https://blog.openshift.com/central-log-management-openshift-enterprise/
 
 Default: undef
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -897,6 +897,16 @@ $dns_infrastructure_names = [
 === manage_firewall
 Indicate whether or not this module will configure the firewall for you
 
+Default: false
+
+=== syslog_enabled
+Direct logs to syslog rather than log files.
+
+Default: undef
+
+=== syslog_central_server_hostname
+Host name of the central log server where rsyslog logs will be forwarded to.
+
 === install_cartridges
 List of cartridges to be installed on the node. Options:
 

--- a/files/rsyslog7_yum.txt
+++ b/files/rsyslog7_yum.txt
@@ -1,0 +1,3 @@
+erase rsyslog
+install rsyslog7 rsyslog7-mmopenshift
+transaction run

--- a/manifests/broker.pp
+++ b/manifests/broker.pp
@@ -18,6 +18,7 @@ class openshift_origin::broker {
   include openshift_origin::firewall::apache
   include openshift_origin::selbooleans
   include openshift_origin::selbooleans::broker_console
+  include openshift_origin::rsyslog
 
   anchor { 'openshift_origin::broker_begin': } ->
   Class['openshift_origin::broker_console_dirs'] ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -692,6 +692,7 @@
 #
 # [*syslog_enabled*]
 #   Direct logs to syslog rather than log files. Only works with OpenShift Enterprise 2.2
+#   Get more details on https://blog.openshift.com/central-log-management-openshift-enterprise/
 #   Default: false
 #
 # [*syslog_central_server_hostname*]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -690,6 +690,14 @@
 # [*manage_firewall*]
 #   Indicate whether or not this module will configure the firewall for you
 #
+# [*syslog_enabled*]
+#   Direct logs to syslog rather than log files. Only works with OpenShift Enterprise 2.2
+#   Default: false
+#
+# [*syslog_central_server_hostname*]
+#   Host name of the central log server where rsyslog logs will be forwarded to.
+#   Default: undef
+#
 # [*install_cartridges*]
 #   List of cartridges to be installed on the node. Options:
 #
@@ -940,6 +948,8 @@ class openshift_origin (
   $install_cartridges_recommended_deps  = undef,
   $install_cartridges_optional_deps     = undef,
   $manage_firewall                      = true,
+  $syslog_enabled                       = false,
+  $syslog_central_server_hostname       = undef,
 ) inherits openshift_origin::params {
   include openshift_origin::role
 

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -20,7 +20,8 @@ class openshift_origin::node {
   include openshift_origin::firewall::node
   include openshift_origin::selbooleans
   include openshift_origin::selbooleans::node
-
+  include openshift_origin::rsyslog
+  include openshift_origin::rsyslog::node
 
   anchor { 'openshift_origin::node_begin': } ->
   Class['openshift_origin::selbooleans'] ->

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -1,0 +1,57 @@
+# Copyright 2014 Red Hat, Inc., All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+class openshift_origin::rsyslog {
+
+  if $::openshift_origin::syslog_enabled == true {
+    file { '/tmp/rsyslog7_yum.txt':
+      ensure => 'file',
+      owner  => 'root',
+      group  => 'root',
+      source => 'puppet:///modules/openshift_origin/rsyslog7_yum.txt'
+    }
+
+    exec {'install_rsyslog7':
+      provider  => shell,
+      path      => [ '/bin/', '/usr/bin/' ],
+      logoutput => true,
+      command   => '/usr/bin/yum shell -y /tmp/rsyslog7_yum.txt',
+      require   => File['/tmp/rsyslog7_yum.txt'],
+      unless    => 'rpm -q rsyslog7'
+    }
+
+    if $::openshift_origin::syslog_central_server_hostname != undef {
+      file { '/etc/rsyslog.d/forward.conf':
+        ensure  => 'file',
+        owner   => 'root',
+        group   => 'root',
+        content => template('openshift_origin/rsyslog/forward_conf.erb'),
+        require => Exec['install_rsyslog7'],
+        notify  => Service['rsyslog']
+      }
+    }
+
+    service { 'rsyslog':
+      ensure  => running,
+      enable  => true,
+      require => Exec['install_rsyslog7']
+    }
+  }else{
+    service { 'rsyslog':
+      ensure => stopped,
+      enable => false,
+    }
+  }
+}
+

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -47,11 +47,6 @@ class openshift_origin::rsyslog {
       enable  => true,
       require => Exec['install_rsyslog7']
     }
-  }else{
-    service { 'rsyslog':
-      ensure => stopped,
-      enable => false,
-    }
   }
 }
 

--- a/manifests/rsyslog/node.pp
+++ b/manifests/rsyslog/node.pp
@@ -1,0 +1,52 @@
+# Copyright 2014 Red Hat, Inc., All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+class openshift_origin::rsyslog::node {
+
+  if $::openshift_origin::syslog_enabled == true{
+    file { '/etc/rsyslog.conf':
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      content => template('openshift_origin/rsyslog/rsyslog_node_conf.erb'),
+      require => Exec['install_rsyslog7'],
+      notify  => Service['rsyslog']
+    }
+
+    file { '/etc/rsyslog.d/openshift.conf':
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      content => template('openshift_origin/rsyslog/rsyslog_node_openshift_conf.erb'),
+      require => Exec['install_rsyslog7'],
+      notify  => Service['rsyslog']
+    }
+  }
+
+  file { '/etc/sysconfig/httpd':
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    content => template('openshift_origin/node/httpd.erb'),
+    notify  => Service['httpd']
+  }
+
+  file { '/etc/openshift/logshifter.conf':
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    content => template('openshift_origin/node/logshifter.conf.erb'),
+    notify  => [Service['openshift-watchman'], Service["${::openshift_origin::params::ruby_scl_prefix}mcollective"]]
+  }
+}

--- a/templates/broker/broker.conf.erb
+++ b/templates/broker/broker.conf.erb
@@ -167,6 +167,11 @@ ALLOW_MULTIPLE_HAPROXY_ON_NODE=<%= scope.lookupvar('::openshift_origin::conf_bro
 # Also this still will not create any DNS entry for the alias; that is an external step.
 ALLOW_ALIAS_IN_DOMAIN="false"
 
+# Whether to send OpenShift log messages to syslog or to files.
+# If true, messages that normally end up in the Rails environment-specific log
+# (e.g. production.rb), usage.log, and user_action.log will instead go to syslog.
+SYSLOG_ENABLED="<%= scope.lookupvar('::openshift_origin::syslog_enabled') %>"
+
 # Customize default app templates for specified framework cartridges.
 # Space-separated list of elements <cartridge-name>|<git url> - URLs must be available for all nodes.
 # URL will be cloned as the git repository for the cartridge at app creation unless the user specifies their own.

--- a/templates/console/console.conf.erb
+++ b/templates/console/console.conf.erb
@@ -146,6 +146,6 @@ PRODUCT_LOGO=<%= scope.lookupvar('::openshift_origin::console_product_logo') %>
 PRODUCT_TITLE=<%= scope.lookupvar('::openshift_origin::console_product_title') %>
 
 # Direct logs to syslog rather than log files:
-#SYSLOG_ENABLED="true"
+SYSLOG_ENABLED="<%= scope.lookupvar('::openshift_origin::syslog_enabled') %>"
 
 SESSION_SECRET="<%= scope.lookupvar('::openshift_origin::conf_console_session_secret') %>"

--- a/templates/node/httpd.erb
+++ b/templates/node/httpd.erb
@@ -1,0 +1,35 @@
+# Configuration file for the httpd service.
+
+#
+# The default processing model (MPM) is the process-based
+# 'prefork' model.  A thread-based model, 'worker', is also
+# available, but does not work with some modules (such as PHP).
+# The service must be stopped before changing this variable.
+#
+#HTTPD=/usr/sbin/httpd.worker
+
+#
+# To pass additional options (for instance, -D definitions) to the
+# httpd binary at startup, set OPTIONS here.
+#
+<% if scope.lookupvar('::openshift_origin::syslog_enabled') == true %>
+OPTIONS="-DOpenShiftFrontendSyslogEnabled -DOpenShiftAnnotateFrontendAccessLog"
+<% else %>
+#OPTIONS=
+<% end %>
+
+#
+# By default, the httpd process is started in the C locale; to
+# change the locale in which the server runs, the HTTPD_LANG
+# variable can be set.
+#
+#HTTPD_LANG=C
+
+#
+# By default, the httpd process will create the file
+# /var/run/httpd/httpd.pid in which it records its process
+# identification number when it starts.  If an alternate location is
+# specified in httpd.conf (via the PidFile directive), the new
+# location needs to be reported in the PIDFILE.
+#
+#PIDFILE=/var/run/httpd/httpd.pid

--- a/templates/node/logshifter.conf.erb
+++ b/templates/node/logshifter.conf.erb
@@ -1,0 +1,11 @@
+queuesize = 1000
+inputbuffersize = 4096
+<% if scope.lookupvar('::openshift_origin::syslog_enabled') == true %>
+outputtype = multi
+<% else %>
+outputtype = file
+<% end %>
+syslogbuffersize = 4096
+filebuffersize = 4096
+outputtypefromenviron = false
+filewriterdir = ~/app-root/logs

--- a/templates/node/node.conf.erb
+++ b/templates/node/node.conf.erb
@@ -39,6 +39,23 @@ PLATFORM_LOG_LEVEL=DEBUG
 PLATFORM_TRACE_LOG_FILE=/var/log/openshift/node/platform-trace.log
 PLATFORM_TRACE_LOG_LEVEL=DEBUG
 
+<% if scope.lookupvar('::openshift_origin::syslog_enabled') == true -%>
+# Uncomment and use the following lines if you want platform log entries to contain
+# parsable attributes associated with a given MCollective request. Possible values
+# are request_id, app_uuid, container_uuid, app_name, app_namespace, cart_name.
+# The entries will appear in the order specified.
+PLATFORM_LOG_CONTEXT_ENABLED=1
+PLATFORM_LOG_CONTEXT_ATTRS=request_id,container_uuid,app_uuid
+PLATFORM_LOG_CLASS=SyslogLogger
+
+# Enable Metrics
+WATCHMAN_METRICS_ENABLED=true
+# How often should the watchman plugin gather metrics
+WATCHMAN_METRICS_INTERVAL=60
+# Metadata to include in messages
+METRICS_METADATA="appName:OPENSHIFT_APP_NAME,gear:OPENSHIFT_GEAR_UUID,app:OPENSHIFT_APP_UUID,ns:OPENSHIFT_NAMESPACE"
+<% end -%>
+
 OPENSHIFT_FRONTEND_HTTP_PLUGINS=<%= scope.lookupvar('::openshift_origin::node_frontend_plugins').map{ |p| 'openshift-origin-frontend-' + p }.join(',') %>
 
 CONTAINERIZATION_PLUGIN=openshift-origin-container-<%= scope.lookupvar('::openshift_origin::node_container_plugin') %>

--- a/templates/rsyslog/forward_conf.erb
+++ b/templates/rsyslog/forward_conf.erb
@@ -1,0 +1,7 @@
+$WorkDirectory /var/lib/rsyslog
+$ActionQueueFileName fwdRule1 # unique name prefix for spool files
+$ActionQueueMaxDiskSpace 1g # 1gb space limit (use as much as possible)
+$ActionQueueSaveOnShutdown on # save messages to disk on shutdown
+$ActionQueueType LinkedList # run asynchronously
+$ActionResumeRetryCount -1 # infinite retries if host is down
+*.* @@<%= scope.lookupvar('::openshift_origin::syslog_central_server_hostname') %>:514

--- a/templates/rsyslog/rsyslog_node_conf.erb
+++ b/templates/rsyslog/rsyslog_node_conf.erb
@@ -1,0 +1,84 @@
+# rsyslog configuration file
+
+# For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html
+# If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
+
+#### MODULES ####
+
+#$ModLoad imuxsock # provides support for local system logging (e.g. via logger command)
+# $ModLoad imjournal # provides access to the systemd journal
+$ModLoad imklog # provides kernel logging support (previously done by rklogd)
+#$ModLoad immark # provides --MARK-- message capability
+# OpenShift plugin module
+module(load="imuxsock" SysSock.Annotate="on" SysSock.ParseTrusted="on" SysSock.UsePIDFromSystem="on")
+module(load="mmopenshift")
+
+# Provides UDP syslog reception
+#$ModLoad imudp
+#$UDPServerRun 514
+
+# Provides TCP syslog reception
+#$ModLoad imtcp
+#$InputTCPServerRun 514
+
+
+#### GLOBAL DIRECTIVES ####
+
+# Use default timestamp format
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+# File syncing capability is disabled by default. This feature is usually not required,
+# not useful and an extreme performance hit
+#$ActionFileEnableSync on
+
+# Include all config files in /etc/rsyslog.d/
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+
+#### RULES ####
+
+# Log all kernel messages to the console.
+# Logging much else clutters up the screen.
+#kern.*                                                 /dev/console
+
+# Log anything (except mail) of level info or higher.
+# Don't log private authentication messages!
+*.info;mail.none;authpriv.none;cron.none                /var/log/messages
+
+# The authpriv file has restricted access.
+authpriv.*                                              /var/log/secure
+
+# Log all the mail messages in one place.
+mail.*                                                  -/var/log/maillog
+
+
+# Log cron stuff
+cron.*                                                  /var/log/cron
+
+# Everybody gets emergency messages
+*.emerg                                                 :omusrmsg:*
+
+# Save news errors of level crit and higher in a special file.
+uucp,news.crit                                          /var/log/spooler
+
+# Save boot messages also to boot.log
+local7.*                                                /var/log/boot.log
+
+
+# ### begin forwarding rule ###
+# The statement between the begin ... end define a SINGLE forwarding
+# rule. They belong together, do NOT split them. If you create multiple
+# forwarding rules, duplicate the whole block!
+# Remote Logging (we use TCP for reliable delivery)
+#
+# An on-disk queue is created for this action. If the remote host is
+# down, messages are spooled to disk and sent when it is up again.
+#$WorkDirectory /var/lib/rsyslog # where to place spool files
+#$ActionQueueFileName fwdRule1 # unique name prefix for spool files
+#$ActionQueueMaxDiskSpace 1g   # 1gb space limit (use as much as possible)
+#$ActionQueueSaveOnShutdown on # save messages to disk on shutdown
+#$ActionQueueType LinkedList   # run asynchronously
+#$ActionResumeRetryCount -1    # infinite retries if host is down
+# remote host is: name/ip:port, e.g. 192.168.0.1:514, port optional
+#*.* @@remote-host:514
+# ### end of the forwarding rule ###

--- a/templates/rsyslog/rsyslog_node_openshift_conf.erb
+++ b/templates/rsyslog/rsyslog_node_openshift_conf.erb
@@ -1,0 +1,20 @@
+# OpenShift plugin configuration
+template(name="OpenShift" type="list")
+{
+property(name="timestamp" dateFormat="rfc3339")
+constant(value=" ")
+property(name="hostname")
+constant(value=" ")
+property(name="syslogtag")
+constant(value=" app=")
+property(name="$!OpenShift!OPENSHIFT_APP_NAME")
+constant(value=" ns=")
+property(name="$!OpenShift!OPENSHIFT_NAMESPACE")
+constant(value=" appUuid=")
+property(name="$!OpenShift!OPENSHIFT_APP_UUID")
+constant(value=" gearUuid=")
+property(name="$!OpenShift!OPENSHIFT_GEAR_UUID")
+property(name="msg" spifno1stsp="on")
+property(name="msg" droplastlf="on")
+constant(value="n")
+}


### PR DESCRIPTION
Hi,

I wrote the puppet parts corresponding to this blog post <https://blog.openshift.com/central-log-management-openshift-enterprise/> to send OpenShift logs to a central rsyslog server.

The following logs are forwarded:
* openshift-broker
* openshift-console
* broker messages (/var/log/messages)
* node apache
* node application logs (logshifter)
* node application metrics
* openshift node platform
* node messages (/var/log/messages)

BSN (mongodb, activemq) is not supported. Mongodb configuration is quite tricky to change.

I focused on OpenShift Enterprise 2.2, because the package `rsyslog7-mmopenshift` is not available on OpenShift Origin.

Cheers