### PR TITLE
Add external access to admin-console with authentication

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -676,6 +676,13 @@ gear groups are distributed.
 
 Default: 1
 
+=== broker_external_access_admin_console
+When true, enable access to the administration console.
+Authentication for the Administration Console is only handled via the
+ldap Broker Auth Plugin, using <code>broker_ldap_admin_console_uri</code>
+
+Default: false
+
 === broker_dns_plugin
 
 DNS plugin used by the broker to register application DNS entries.
@@ -729,6 +736,10 @@ Default is anonymous bind.
 === broker_ldap_bind_password
 Password of bind user set in broker_ldap_bind_dn.
 Default is anonymous bind with a blank password.
+
+=== broker_admin_console_ldap_uri
+URI to the LDAP server for admin console access (e.g. ldap://ldap.example.com:389/ou=People,dc=my-domain,dc=com?uid?sub?(objectClass=*)).
+Set <code>broker_external_access_admin_console</code> to enable this feature
 
 === node_shmmax
 kernel.shmmax sysctl setting for /etc/sysctl.conf

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -481,6 +481,12 @@
 #   List of all gear sizes that newly created users will be able to create
 #   Default: ['small']
 #
+# [*broker_external_access_admin_console*]
+#   When true, enable access to the administration console.
+#   Authentication for the Administration Console is only handled via the
+#   ldap Broker Auth Plugin, using <code>broker_ldap_admin_console_uri</code>
+#   Default: false
+#
 # [*broker_dns_plugin*]
 #   DNS plugin used by the broker to register application DNS entries.
 #   Options:
@@ -528,6 +534,10 @@
 # [*broker_ldap_bind_password*]
 # Password of bind user set in broker_ldap_bind_dn.
 # Default is anonymous bind with a blank password.
+#
+# [*broker_admin_console_ldap_uri*]
+# URI to the LDAP server for admin console access (e.g. ldap://ldap.example.com:389/ou=People,dc=my-domain,dc=com?uid?sub?(objectClass=*)).
+# Set <code>broker_external_access_admin_console</code> to enable this feature
 #
 # [*node_shmmax*]
 #   kernel.shmmax sysctl setting for /etc/sysctl.conf
@@ -915,6 +925,7 @@ class openshift_origin (
   $conf_default_gear_size               = 'small',
   $conf_default_max_domains             = '10',
   $conf_default_max_gears               = '100',
+  $broker_external_access_admin_console = false,
   $broker_dns_plugin                    = 'nsupdate',
   $broker_auth_plugin                   = 'htpasswd',
   $broker_krb_service_name              = '',
@@ -923,6 +934,7 @@ class openshift_origin (
   $broker_ldap_uri                      = '',
   $broker_ldap_bind_dn                  = '',
   $broker_ldap_bind_password            = '',
+  $broker_admin_console_ldap_uri        = '',
   $node_shmmax                          = $openshift_origin::params::node_shmmax,
   $node_shmall                          = $openshift_origin::params::node_shmall,
   $node_container_plugin                = 'selinux',

--- a/manifests/plugins/frontend/apache.pp
+++ b/manifests/plugins/frontend/apache.pp
@@ -26,8 +26,20 @@ class openshift_origin::plugins::frontend::apache {
   }
 
   if 'broker' in $::openshift_origin::roles {
+    file { 'broker proxy config':
+      ensure  => present,
+      path    => '/etc/httpd/conf.d/000002_openshift_origin_broker_proxy.conf',
+      content => template('openshift_origin/plugins/frontend/apache/broker_proxy.conf.erb'),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      require => Package['httpd'],
+      notify  => Service['httpd'],
+    }
+
     $httpd_servername_path    = '/etc/httpd/conf.d/000002_openshift_origin_broker_servername.conf'
     $servername_conf_template = 'openshift_origin/plugins/frontend/apache/broker_servername.conf.erb'
+
   } elsif 'node' in $::openshift_origin::roles {
     $httpd_servername_path    = '/etc/httpd/conf.d/000001_openshift_origin_node_servername.conf'
     $servername_conf_template = 'openshift_origin/plugins/frontend/apache/node_servername.conf.erb'

--- a/templates/broker/plugins/auth/ldap/openshift-origin-auth-remote-user-ldap.conf.erb
+++ b/templates/broker/plugins/auth/ldap/openshift-origin-auth-remote-user-ldap.conf.erb
@@ -76,3 +76,17 @@ LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
     Allow from all
   </IfVersion>
 </LocationMatch>
+
+<% if scope.lookupvar('::openshift_origin::broker_admin_console_ldap_uri') != '' %>
+<Location /admin-console>
+    AuthName "OpenShift Administration Console"
+    AuthType Basic
+    AuthBasicProvider ldap
+    AuthLDAPURL "<%= scope.lookupvar('::openshift_origin::broker_admin_console_ldap_uri') %>"
+    require valid-user
+
+    Order Deny,Allow
+    Deny from all
+    Satisfy any
+</Location>
+<% end %>

--- a/templates/plugins/frontend/apache/broker_proxy.conf.erb
+++ b/templates/plugins/frontend/apache/broker_proxy.conf.erb
@@ -1,0 +1,63 @@
+#
+# This configuration is to proxy to an OpenShift broker
+# (and optional developer console) running in a separate
+# httpd instance.
+#
+# If the broker and node are installed on the same host,
+# typically node configuration will provide vhosts prior
+# to the ones defined here, so these will not be used.
+
+<Directory />
+    Options FollowSymLinks
+    AllowOverride None
+</Directory>
+
+<VirtualHost *:80>
+  # ServerName we will inherit from other config;
+  # ServerAlias is to make sure "localhost" traffic goes here regardless.
+  ServerAlias localhost
+  ServerAdmin root@localhost
+  DocumentRoot /var/www/html
+  RewriteEngine              On
+  RewriteRule     ^/$    https://%{HTTP_HOST}/console [R,L]
+  RewriteRule     ^(.*)$     https://%{HTTP_HOST}$1 [R,L]
+</VirtualHost>
+
+<VirtualHost *:443>
+  # ServerName we will inherit from other config;
+  # ServerAlias is to make sure "localhost" traffic goes here regardless.
+  ServerAlias localhost
+  ServerAdmin root@localhost
+  DocumentRoot /var/www/html
+  RewriteEngine              On
+  RewriteRule     ^/$    https://%{HTTP_HOST}/console [R,L]
+  SSLEngine on
+  SSLProxyEngine on
+  SSLCertificateFile /etc/pki/tls/certs/localhost.crt
+  SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
+  RequestHeader set X_FORWARDED_PROTO 'https'
+  RequestHeader set Front-End-Https "On"
+  ProxyPass /console http://127.0.0.1:8118/console
+  ProxyPassReverse /console http://127.0.0.1:8118/console
+  ProxyPass /broker http://127.0.0.1:8080/broker
+  <% if scope.lookupvar('::openshift_origin::broker_external_access_admin_console') == true %>
+  ProxyPass /admin-console http://127.0.0.1:8080/admin-console
+  ProxyPass /assets http://127.0.0.1:8080/assets
+  <% end %>
+  ProxyPassReverse / http://127.0.0.1:8080/
+
+  # SSL Defaults for this vhost (secure broker and console).
+  SSLProtocol ALL -SSLv2 -SSLv3
+  SSLHonorCipherOrder On
+  # These are recommendations based on known cipher research as of March 2014;
+  # please consult your own security experts to determine your own appropriate settings.
+  SSLCipherSuite kEECDH:+kEECDH+SHA:kEDH:+kEDH+SHA:+kEDH+CAMELLIA:kECDH:+kECDH+SHA:kRSA:+kRSA+SHA:+kRSA+CAMELLIA:!aNULL:!eNULL:!SSLv2:!RC4:!DES:!EXP:!SEED:!IDEA:+3DES
+
+  # Limits how long requests to broker/console can take to respond before connection is dropped with a 502 error
+  ProxyTimeout 300
+</VirtualHost>
+
+ProxyPreserveHost On
+TraceEnable off
+# Required for the remote-user plugin
+RequestHeader unset X-Remote-User


### PR DESCRIPTION
This Pull Request add external access to the Administration Console with LDAP Authentication.

I followed the deployment guide:
* https://access.redhat.com/documentation/en-US/OpenShift_Enterprise/2/html/Deployment_Guide/Accessing_the_Administration_Console.html
* https://access.redhat.com/documentation/en-US/OpenShift_Enterprise/2/html/Deployment_Guide/Configuring_Authentication_for_the_Administration_Console.html