### PR TITLE
Modify the OpenShift logging and metrics file

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -791,6 +791,11 @@ External facing network device. Used for routing and traffic control setup.
 
 Default: eth0
 
+=== conf_node_proxy_ports_per_gear
+Number of proxy ports available per gear.
+
+Default: 5
+
 === conf_node_public_key
 === conf_node_private_key
 Public and private keys used for gears on the default domain. Both values

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -592,6 +592,10 @@
 #   External facing network device. Used for routing and traffic control setup.
 #   Default: eth0
 #
+# [*conf_node_proxy_ports_per_gear*]
+#   Number of proxy ports available per gear.
+#   Default: 5
+#
 # [*conf_node_public_key*]
 # [*conf_node_private_key*]
 #   Public and private keys used for gears on the default domain. Both values
@@ -929,6 +933,7 @@ class openshift_origin (
   $node_frontend_plugins                = ['apache-vhost','nodejs-websocket'],
   $node_unmanaged_users                 = [],
   $conf_node_external_eth_dev           = 'eth0',
+  $conf_node_proxy_ports_per_gear       = '5',
   $conf_node_public_key                 = undef,
   $conf_node_private_key                = undef,
   $conf_node_supplementary_posix_groups = '',

--- a/templates/node/node.conf.erb
+++ b/templates/node/node.conf.erb
@@ -30,7 +30,7 @@ CARTRIDGE_BASE_PATH="/usr/libexec/openshift/cartridges"   # Locations where cart
 LAST_ACCESS_DIR="/var/lib/openshift/.last_access"         # Location to maintain last accessed time for gears
 APACHE_ACCESS_LOG="/var/log/httpd/openshift_log"          # Localion of httpd for node
 PROXY_MIN_PORT_NUM=35531                                  # Lower bound of port numbers used to proxy ports externally
-PROXY_PORTS_PER_GEAR=5                                    # Number of proxy ports available per gear
+PROXY_PORTS_PER_GEAR=<%= scope.lookupvar('::openshift_origin::conf_node_proxy_ports_per_gear') %>                            # Number of proxy ports available per gear
 CREATE_APP_SYMLINKS=0                                     # If set to 1, creates gear-name symlinks to the UUID directories (debugging only)
 OPENSHIFT_HTTP_CONF_DIR="/etc/httpd/conf.d/openshift"
 

--- a/templates/node/node.conf.erb
+++ b/templates/node/node.conf.erb
@@ -28,7 +28,7 @@ GEAR_SUPL_GRPS="<%= scope.lookupvar('::openshift_origin::conf_node_supplementary
 OPENSHIFT_NODE_PLUGINS=""                                 # Extentions to load when customize/observe openshift-origin-node models
 CARTRIDGE_BASE_PATH="/usr/libexec/openshift/cartridges"   # Locations where cartridges are installed
 LAST_ACCESS_DIR="/var/lib/openshift/.last_access"         # Location to maintain last accessed time for gears
-APACHE_ACCESS_LOG="/var/log/httpd/access_log"             # Localion of httpd for node
+APACHE_ACCESS_LOG="/var/log/httpd/openshift_log"          # Localion of httpd for node
 PROXY_MIN_PORT_NUM=35531                                  # Lower bound of port numbers used to proxy ports externally
 PROXY_PORTS_PER_GEAR=5                                    # Number of proxy ports available per gear
 CREATE_APP_SYMLINKS=0                                     # If set to 1, creates gear-name symlinks to the UUID directories (debugging only)


### PR DESCRIPTION
Openshift nodes use APACHE_ACCESS_LOG variable for logging and metrics (idling, etc...) 
This variable should be set to /var/log/httpd/openshift_log (DEFAULT)
Failing to do so result to a bad handling of idling gears etc... 