### PR TITLE
bugfix_397: change in config variables between M4 and OSE

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ CHANGELOG
 
 2015-05-19
 
- * Adding option for proxy_ports_per_gear
+ * Adding option for PROXY_PORTS_PER_GEAR (origin) / PORTS_PER_USER (ose)
  * Modify the OpenShift logging and metrics file
  * Add dependency for file resource '/etc/openshift/logshifter.conf'
  * Double quotes instead of escaped singles for exec 'regen node routes'
@@ -17,7 +17,7 @@ CHANGELOG
  * Add extra district, zone and region options
  * Clean up to avoid unnecessary notices and service restarts
  * Remove unnecessary packages from puppet management
- * Add support for USE_PREDICTABLE_GEAR_UUIDS
+ * Add support for USE_PREDICTABLE_GEAR_UUIDS (ose only)
  * Add puppetlabs-concat < 2.0.0 dependency as workaround for puppetlabs-haproxy
  < 2.0.0 dependency resolution issues
 

--- a/templates/broker/broker.conf.erb
+++ b/templates/broker/broker.conf.erb
@@ -191,6 +191,7 @@ DEFAULT_REGION_NAME="<%= scope.lookupvar('::openshift_origin::conf_broker_defaul
 # Allow region selection when creating applications. Default is true
 ALLOW_REGION_SELECTION="<%= scope.lookupvar('::openshift_origin::conf_broker_allow_region_selection') %>"
 
+<% if scope.lookupvar('::openshift_origin::ose_version') != "" -%>
 # Create new gear UUIDs (and thus gear usernames) with the format:
 #    <domain_namespace>­<app_name>­<gear_index>
 USE_PREDICTABLE_GEAR_UUIDS="<%= scope.lookupvar('::openshift_origin::conf_broker_use_predictable_gear_uuids') %>"
@@ -199,4 +200,5 @@ USE_PREDICTABLE_GEAR_UUIDS="<%= scope.lookupvar('::openshift_origin::conf_broker
 # Reject app creation if domain + app name larger 
 # (set to 26 to leave 2 chars for hyphens and 4 chars for up to 9999 gears.)
 LIMIT_APP_NAME_CHARS=26
+<% end %>
 <% end %>

--- a/templates/node/node.conf.erb
+++ b/templates/node/node.conf.erb
@@ -23,14 +23,23 @@ GEAR_GECOS="OpenShift guest"                              # Gecos information to
 GEAR_MIN_UID=1000                                         # Lower bound of UID used to create gears
 GEAR_MAX_UID=6500                                         # Upper bound of UID used to create gears
 <% if scope.lookupvar('::openshift_origin::conf_node_supplementary_posix_groups') != "" -%>
+<% if scope.lookupvar('::openshift_origin::ose_version') != "" -%>
+GEAR_SUPPLEMENTARY_GROUPS="<%= scope.lookupvar('::openshift_origin::conf_node_supplementary_posix_groups') %>"  # Supplementary groups for gear UIDs (comma separated list)
+<% else -%>
 GEAR_SUPL_GRPS="<%= scope.lookupvar('::openshift_origin::conf_node_supplementary_posix_groups') %>"  # Supplementary groups for gear UIDs (comma separated list)
+<% end -%>
 <% end -%>
 OPENSHIFT_NODE_PLUGINS=""                                 # Extentions to load when customize/observe openshift-origin-node models
 CARTRIDGE_BASE_PATH="/usr/libexec/openshift/cartridges"   # Locations where cartridges are installed
 LAST_ACCESS_DIR="/var/lib/openshift/.last_access"         # Location to maintain last accessed time for gears
 APACHE_ACCESS_LOG="/var/log/httpd/openshift_log"          # Localion of httpd for node
+<% if scope.lookupvar('::openshift_origin::ose_version') != "" -%>
+PORT_BEGIN=35531					  # Lower bound of port numbers used to proxy ports externally
+PORTS_PER_USER=<%= scope.lookupvar('::openshift_origin::conf_node_proxy_ports_per_gear') %>                            # Number of proxy ports available per gear
+<% else -%>
 PROXY_MIN_PORT_NUM=35531                                  # Lower bound of port numbers used to proxy ports externally
 PROXY_PORTS_PER_GEAR=<%= scope.lookupvar('::openshift_origin::conf_node_proxy_ports_per_gear') %>                            # Number of proxy ports available per gear
+<% end -%>
 CREATE_APP_SYMLINKS=0                                     # If set to 1, creates gear-name symlinks to the UUID directories (debugging only)
 OPENSHIFT_HTTP_CONF_DIR="/etc/httpd/conf.d/openshift"
 


### PR DESCRIPTION
There's been a change in config variables between M4 and more recent OSE releases. 
New conditional statements based on ose_version parameter so as to distinguish Origin and OSE. 