### PR TITLE
Ensure node configuration is set before starting the openshift-watchman service

### DIFF
--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -260,6 +260,7 @@ class openshift_origin::node {
       enable  => true,
       require => [
         Package['rubygem-openshift-origin-node'],
+        File['openshift node config'],
         Package['openshift-origin-node-util'],
         Service['openshift-gears'],
       ],


### PR DESCRIPTION
The watchman script loads openshift-origin-node, which requires that all frontends specified in OPENSHIFT_FRONTEND_HTTP_PLUGINS of /etc/openshift/node.conf be present. The default value may include a frontend that is not present, causing openshift-watchman to fail to load openshift-origin-node.

Fixes https://github.com/openshift/origin-server/issues/5693