### PR TITLE
Updated broker_proxy_conf with ProxyPass assets for icons

### DIFF
--- a/templates/plugins/frontend/apache/broker_proxy.conf.erb
+++ b/templates/plugins/frontend/apache/broker_proxy.conf.erb
@@ -39,6 +39,8 @@
   RequestHeader set Front-End-Https "On"
   ProxyPass /console http://127.0.0.1:8118/console
   ProxyPassReverse /console http://127.0.0.1:8118/console
+  ProxyPass /assets http://127.0.0.1:8118/console/assets
+  ProxyPassReverse /assets http://127.0.0.1:8118/console/assets
   ProxyPass /broker http://127.0.0.1:8080/broker
   <% if scope.lookupvar('::openshift_origin::broker_external_access_admin_console') == true %>
   ProxyPass /admin-console http://127.0.0.1:8080/admin-console


### PR DESCRIPTION
As I didn't have any icons with the current installation of OO via Puppet, I found how activate them adding two lines in the broker_proxy_conf.

Source: https://lists.openshift.redhat.com/openshift-archives/users/2014-January/msg00124.html