### PR TITLE
removed space at start of a line in broker.conf.erb

### DIFF
--- a/templates/broker/broker.conf.erb
+++ b/templates/broker/broker.conf.erb
@@ -44,7 +44,7 @@ DEFAULT_MAX_TRACKED_ADDTL_STORAGE_PER_GEAR="0"
 <% if scope.lookupvar('::openshift_origin::mongodb_replicasets') == true %>
 MONGO_HOST_PORT="<%= scope.lookupvar('::openshift_origin::mongodb_replicasets_members').join(',') %>"
 <% else %>
- MONGO_HOST_PORT="<%= scope.lookupvar('::openshift_origin::datastore_fqdn') %>:<%= scope.lookupvar('::openshift_origin::mongodb_port') %>"
+MONGO_HOST_PORT="<%= scope.lookupvar('::openshift_origin::datastore_fqdn') %>:<%= scope.lookupvar('::openshift_origin::mongodb_port') %>"
 <% end %>
 MONGO_USER="<%= scope.lookupvar('::openshift_origin::mongodb_broker_user') %>"
 MONGO_PASSWORD="<%= scope.lookupvar('::openshift_origin::mongodb_broker_password') %>"


### PR DESCRIPTION
According to this line in oo-accept-broker (https://github.com/openshift/origin-server/blob/e8bbb7861a65ac24d5f5bd17179f494a8272bb03/broker-util/oo-accept-broker#L152)

    MONGO_HOST=$(grep -e "^MONGO_HOST_PORT=" $BROKER_CONF | cut -d= -f2)

The space at the start of the line should not be there