### PR TITLE
Fix unwanted space in front of MONGO_HOST_PORT line

### DIFF
--- a/templates/broker/broker.conf.erb
+++ b/templates/broker/broker.conf.erb
@@ -44,7 +44,7 @@ DEFAULT_MAX_TRACKED_ADDTL_STORAGE_PER_GEAR="0"
 <% if scope.lookupvar('::openshift_origin::mongodb_replicasets') == true %>
 MONGO_HOST_PORT="<%= scope.lookupvar('::openshift_origin::mongodb_replicasets_members').join(',') %>"
 <% else %>
- MONGO_HOST_PORT="<%= scope.lookupvar('::openshift_origin::datastore_fqdn') %>:<%= scope.lookupvar('::openshift_origin::mongodb_port') %>"
+MONGO_HOST_PORT="<%= scope.lookupvar('::openshift_origin::datastore_fqdn') %>:<%= scope.lookupvar('::openshift_origin::mongodb_port') %>"
 <% end %>
 MONGO_USER="<%= scope.lookupvar('::openshift_origin::mongodb_broker_user') %>"
 MONGO_PASSWORD="<%= scope.lookupvar('::openshift_origin::mongodb_broker_password') %>"
@@ -203,7 +203,7 @@ ALLOW_REGION_SELECTION="<%= scope.lookupvar('::openshift_origin::conf_broker_all
 USE_PREDICTABLE_GEAR_UUIDS="<%= scope.lookupvar('::openshift_origin::conf_broker_use_predictable_gear_uuids') %>"
 <% if scope.lookupvar('::openshift_origin::conf_broker_use_predictable_gear_uuids') == true %>
 # Gear UUIDs that are too large to fit in 32 char limit will fall back to 24­hex chars.
-# Reject app creation if domain + app name larger 
+# Reject app creation if domain + app name larger
 # (set to 26 to leave 2 chars for hyphens and 4 chars for up to 9999 gears.)
 LIMIT_APP_NAME_CHARS=26
 <% end %>


### PR DESCRIPTION
There is a typo (white space) that was introduced unintentionally into
the code base the previous commit:

<https://github.com/openshift/puppet-openshift_origin/commit/22e3bbbab10133fef3d4b414030cc6833bc42363>

The white space occupied right before MONGO_HOST_PORT line. This unwanted
issue cause the oo-accept-broker to fail in Enterprise devenv as it
couldn't locate the MONGO_HOST_PORT line.

This commit will remove the space and the oo-accept-broker should be able
to locate the line for mango host info correctly.

Signed-off-by: Vu Dinh <vdinh@redhat.com>